### PR TITLE
feat: enable drag and drop lanes on kanban board

### DIFF
--- a/src/app/features/board/README.md
+++ b/src/app/features/board/README.md
@@ -6,7 +6,8 @@ Fornecer um quadro Kanban gamificado que represente a hierarquia Feature → His
 ## Decisões técnicas
 - **Signals** em `BoardState` para manter estado reativo com baixo acoplamento.
 - **ViewModels tipados** (`BoardColumnViewModel`, `BoardCardViewModel`) garantem que a UI receba dados prontos para renderização.
-- **Componentes standalone** desacoplados (`BoardColumn`, `BoardCard`) facilitam testes e futuras integrações com drag-and-drop.
+- **Componentes standalone** desacoplados (`BoardColumn`, `BoardCard`) facilitam testes e composição de UI.
+- **Drag-and-drop nativo** com HTML5 + `BoardDragState` garante movimentação entre colunas respeitando limites de WIP e workflow configurado.
 - **Transições validadas** no serviço (`moveStory`) respeitam workflow configurável e limites de WIP.
 
 ## Uso
@@ -20,6 +21,6 @@ Rotas lazy-loaded já expõem a `BoardPage`. Componentes podem ser reutilizados 
 
 ## Checklist de manutenção
 - [ ] Atualizar mocks em `BoardState` ao integrar API real.
-- [ ] Garantir acessibilidade (aria-labels e feedback textual) quando adicionar drag-and-drop.
+- [ ] Revisar acessibilidade (aria-grabbed, mensagens) quando ampliar a interação de drag-and-drop.
 - [ ] Ajustar tokens de cores globais em `styles.scss` ao introduzir temas.
 - [ ] Cobrir novas regras de transição com testes em `board-state.service.spec.ts`.

--- a/src/app/features/board/components/board-card/board-card.component.html
+++ b/src/app/features/board/components/board-card/board-card.component.html
@@ -1,4 +1,12 @@
-<article class="card" [attr.data-priority]="card().priorityLabel">
+<article
+  class="card"
+  [class.card--dragging]="isDragging()"
+  [attr.data-priority]="card().priorityLabel"
+  [attr.aria-grabbed]="isDragging()"
+  draggable="true"
+  (dragstart)="onDragStart($event)"
+  (dragend)="onDragEnd()"
+>
   <header class="card__header">
     <span class="card__priority" [style.background]="card().priorityColor">{{ card().priorityLabel }}</span>
     <span class="card__xp" aria-label="Recompensa de experiência">{{ card().xp }} XP</span>

--- a/src/app/features/board/components/board-card/board-card.component.scss
+++ b/src/app/features/board/components/board-card/board-card.component.scss
@@ -7,12 +7,20 @@
   padding: 1rem;
   box-shadow: 0 12px 30px -12px rgba(14, 11, 36, 0.65);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: grab;
+  user-select: none;
 }
 
 .card:hover,
 .card:focus-within {
   transform: translateY(-3px);
   box-shadow: 0 18px 40px -12px rgba(14, 11, 36, 0.8);
+}
+
+.card--dragging {
+  opacity: 0.6;
+  cursor: grabbing;
+  box-shadow: 0 10px 24px -12px rgba(14, 11, 36, 0.6);
 }
 
 .card__header {

--- a/src/app/features/board/components/board-card/board-card.component.ts
+++ b/src/app/features/board/components/board-card/board-card.component.ts
@@ -1,6 +1,8 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, signal, inject } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 import type { BoardCardViewModel } from '../../state/board.models';
+import { BoardDragState } from '../../state/board-drag-state.service';
+import { STORY_ID_MIME_TYPE, STORY_STATUS_MIME_TYPE } from '../board-dnd.constants';
 
 @Component({
   selector: 'kanban-board-card',
@@ -12,4 +14,26 @@ import type { BoardCardViewModel } from '../../state/board.models';
 })
 export class BoardCardComponent {
   readonly card = input.required<BoardCardViewModel>();
+  protected readonly isDragging = signal(false);
+
+  private readonly dragState = inject(BoardDragState);
+
+  protected onDragStart(event: DragEvent): void {
+    const card = this.card();
+    event.dataTransfer?.setData('text/plain', card.title);
+    event.dataTransfer?.setData(STORY_ID_MIME_TYPE, card.id);
+    event.dataTransfer?.setData(STORY_STATUS_MIME_TYPE, card.statusId);
+    event.dataTransfer?.setData('application/json', JSON.stringify({ id: card.id, status: card.statusId }));
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+    }
+
+    this.dragState.startDrag(card.id, card.statusId);
+    this.isDragging.set(true);
+  }
+
+  protected onDragEnd(): void {
+    this.dragState.endDrag();
+    this.isDragging.set(false);
+  }
 }

--- a/src/app/features/board/components/board-column/board-column.component.html
+++ b/src/app/features/board/components/board-column/board-column.component.html
@@ -1,4 +1,13 @@
-<article class="column" [attr.data-status]="column().status.id">
+<article
+  class="column"
+  [class.column--active-drop]="isDragOver()"
+  [class.column--invalid]="isDropRejected()"
+  [attr.data-status]="column().status.id"
+  (dragenter)="onDragEnter($event)"
+  (dragover)="onDragOver($event)"
+  (dragleave)="onDragLeave($event)"
+  (drop)="onDrop($event)"
+>
   <header class="column__header">
     <div class="column__identity">
       <span class="column__icon" [style.background]="column().status.color" aria-hidden="true">

--- a/src/app/features/board/components/board-column/board-column.component.scss
+++ b/src/app/features/board/components/board-column/board-column.component.scss
@@ -1,13 +1,50 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 clamp(18rem, 22vw, 21rem);
+  width: clamp(18rem, 22vw, 21rem);
+  min-width: 17rem;
+}
+
 .column {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background: var(--hk-surface);
-  border: 1px solid var(--hk-border);
-  border-radius: 1.25rem;
+  background: rgba(20, 22, 42, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
   padding: 1rem;
-  min-height: 320px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  min-height: 24rem;
+  height: 100%;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.column--active-drop {
+  border-color: var(--hk-accent);
+  background: rgba(124, 92, 255, 0.15);
+  box-shadow: 0 0 0 2px var(--hk-accent-soft), 0 20px 32px -24px rgba(14, 12, 41, 0.8);
+}
+
+.column--invalid {
+  border-color: var(--hk-danger);
+  animation: column-shake 0.35s ease;
+}
+
+@keyframes column-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  50% {
+    transform: translateX(4px);
+  }
+  75% {
+    transform: translateX(-2px);
+  }
 }
 
 .column__header {
@@ -15,6 +52,8 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 0.75rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .column__identity {
@@ -63,15 +102,27 @@
 
 .column__cards {
   margin: 0;
-  padding: 0;
+  padding: 0 0.35rem 0.5rem 0;
   list-style: none;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.column__cards::-webkit-scrollbar {
+  width: 0.45rem;
+}
+
+.column__cards::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .column__empty {
   margin: 0;
-  padding: 1rem;
+  padding: 1.25rem 1rem;
   border-radius: 0.75rem;
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.04);

--- a/src/app/features/board/components/board-column/board-column.component.ts
+++ b/src/app/features/board/components/board-column/board-column.component.ts
@@ -1,7 +1,9 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, input, signal, inject } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 import type { BoardColumnViewModel } from '../../state/board.models';
 import { BoardCardComponent } from '../board-card/board-card.component';
+import { BoardState } from '../../state/board-state.service';
+import { BoardDragState } from '../../state/board-drag-state.service';
 
 @Component({
   selector: 'kanban-board-column',
@@ -11,10 +13,119 @@ import { BoardCardComponent } from '../board-card/board-card.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgFor, NgIf, BoardCardComponent],
 })
-export class BoardColumnComponent {
+export class BoardColumnComponent implements OnDestroy {
   readonly column = input.required<BoardColumnViewModel>();
+  protected readonly isDragOver = signal(false);
+  protected readonly isDropRejected = signal(false);
+
+  private readonly boardState = inject(BoardState);
+  private readonly dragState = inject(BoardDragState);
+  private dropFeedbackTimeoutId: number | undefined;
 
   protected trackCard(_: number, card: BoardColumnViewModel['cards'][number]): string {
     return card.id;
+  }
+
+  protected onDragEnter(event: DragEvent): void {
+    if (!this.canAcceptDrop()) {
+      this.isDragOver.set(false);
+      return;
+    }
+
+    this.clearDropFeedbackTimer();
+    this.isDropRejected.set(false);
+    event.preventDefault();
+    this.isDragOver.set(true);
+  }
+
+  protected onDragOver(event: DragEvent): void {
+    if (!this.canAcceptDrop()) {
+      this.isDragOver.set(false);
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'none';
+      }
+      return;
+    }
+
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    this.isDragOver.set(true);
+  }
+
+  protected onDragLeave(event: DragEvent): void {
+    if (!(event.currentTarget instanceof HTMLElement)) {
+      this.isDragOver.set(false);
+      return;
+    }
+
+    const nextElement = event.relatedTarget as Node | null;
+    if (nextElement && event.currentTarget.contains(nextElement)) {
+      return;
+    }
+
+    this.isDragOver.set(false);
+  }
+
+  protected onDrop(event: DragEvent): void {
+    event.preventDefault();
+    const storyId = this.dragState.draggedStoryId();
+    const targetStatusId = this.column().status.id;
+
+    this.isDragOver.set(false);
+
+    if (!storyId) {
+      this.dragState.endDrag();
+      return;
+    }
+
+    const moved = this.boardState.moveStory(storyId, targetStatusId);
+    if (!moved) {
+      this.triggerDropRejected();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'none';
+      }
+    } else if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+
+    this.dragState.endDrag();
+  }
+
+  ngOnDestroy(): void {
+    this.clearDropFeedbackTimer();
+  }
+
+  private canAcceptDrop(): boolean {
+    const storyId = this.dragState.draggedStoryId();
+    const sourceStatusId = this.dragState.sourceStatusId();
+    if (!storyId || !sourceStatusId) {
+      return false;
+    }
+
+    const targetStatusId = this.column().status.id;
+    if (sourceStatusId === targetStatusId) {
+      return false;
+    }
+
+    return this.boardState.canMoveStory(storyId, targetStatusId);
+  }
+
+  private triggerDropRejected(): void {
+    this.isDropRejected.set(true);
+    this.clearDropFeedbackTimer();
+
+    this.dropFeedbackTimeoutId = window.setTimeout(() => {
+      this.isDropRejected.set(false);
+      this.dropFeedbackTimeoutId = undefined;
+    }, 450);
+  }
+
+  private clearDropFeedbackTimer(): void {
+    if (this.dropFeedbackTimeoutId !== undefined) {
+      window.clearTimeout(this.dropFeedbackTimeoutId);
+      this.dropFeedbackTimeoutId = undefined;
+    }
   }
 }

--- a/src/app/features/board/components/board-dnd.constants.ts
+++ b/src/app/features/board/components/board-dnd.constants.ts
@@ -1,0 +1,2 @@
+export const STORY_ID_MIME_TYPE = 'application/x-hero-kanban-story-id';
+export const STORY_STATUS_MIME_TYPE = 'application/x-hero-kanban-story-status';

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -155,8 +155,16 @@
 }
 
 .board__columns {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  align-items: start;
+  display: flex;
+  gap: 1.25rem;
+  align-items: stretch;
+  overflow-x: auto;
+  padding-bottom: 0.75rem;
+  padding-right: 0.5rem;
+  scroll-snap-type: x proximity;
+  min-height: 60vh;
+}
+
+.board__columns > kanban-board-column {
+  scroll-snap-align: start;
 }

--- a/src/app/features/board/state/board-drag-state.service.ts
+++ b/src/app/features/board/state/board-drag-state.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class BoardDragState {
+  private readonly _draggedStoryId = signal<string | null>(null);
+  private readonly _sourceStatusId = signal<string | null>(null);
+
+  readonly draggedStoryId = this._draggedStoryId.asReadonly();
+  readonly sourceStatusId = this._sourceStatusId.asReadonly();
+
+  startDrag(storyId: string, statusId: string): void {
+    this._draggedStoryId.set(storyId);
+    this._sourceStatusId.set(statusId);
+  }
+
+  endDrag(): void {
+    this._draggedStoryId.set(null);
+    this._sourceStatusId.set(null);
+  }
+}

--- a/src/app/features/board/state/board-state.service.spec.ts
+++ b/src/app/features/board/state/board-state.service.spec.ts
@@ -28,4 +28,12 @@ describe('BoardState', () => {
     const blockedMove = service.moveStory('story-onboarding', 'release');
     expect(blockedMove).toBeFalse();
   });
+
+  it('should expose canMoveStory with the same rules applied on move', () => {
+    expect(service.canMoveStory('story-team-buffs', 'ready')).toBeTrue();
+    expect(service.canMoveStory('story-team-buffs', 'done')).toBeFalse();
+
+    service.moveStory('story-mission-engine', 'release');
+    expect(service.canMoveStory('story-onboarding', 'release')).toBeFalse();
+  });
 });

--- a/src/app/features/board/state/board-state.service.ts
+++ b/src/app/features/board/state/board-state.service.ts
@@ -286,10 +286,26 @@ export class BoardState {
   });
 
   moveStory(storyId: string, nextStatusId: string): boolean {
-    const statusesById = new Map(this._statuses().map((status) => [status.id, status] as const));
+    if (!this.isMoveAllowed(storyId, nextStatusId)) {
+      return false;
+    }
+
+    this._stories.update((stories) =>
+      stories.map((item) => (item.id === storyId ? { ...item, statusId: nextStatusId } : item)),
+    );
+
+    return true;
+  }
+
+  canMoveStory(storyId: string, nextStatusId: string): boolean {
+    return this.isMoveAllowed(storyId, nextStatusId);
+  }
+
+  private isMoveAllowed(storyId: string, nextStatusId: string): boolean {
+    const statusesById = this.getStatusesById();
     const story = this._stories().find((item) => item.id === storyId);
     const nextStatus = statusesById.get(nextStatusId);
-    if (!story || !nextStatus) {
+    if (!story || !nextStatus || story.statusId === nextStatusId) {
       return false;
     }
 
@@ -305,11 +321,11 @@ export class BoardState {
       return false;
     }
 
-    this._stories.update((stories) =>
-      stories.map((item) => (item.id === storyId ? { ...item, statusId: nextStatusId } : item)),
-    );
-
     return true;
+  }
+
+  private getStatusesById(): Map<string, BoardStatus> {
+    return new Map(this._statuses().map((status) => [status.id, status] as const));
   }
 
   private toCardViewModel(story: Story): BoardCardViewModel {


### PR DESCRIPTION
## Summary
- restyle board columns to behave like Jira-style lanes and keep headers and cards aligned
- add HTML5 drag-and-drop with shared drag state so stories can move between columns respecting workflow rules
- expose canMoveStory checks, update specs, and document the new interaction in the board README

## Testing
- npm run build *(fails: font inlining request to fonts.googleapis.com returned 400)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbff048508333a732926437a4401f