### PR TITLE
feat: route hero profile and board customization views

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,19 @@
 <header class="shell-header" role="banner">
+  <button
+    type="button"
+    class="menu-toggle"
+    (click)="toggleMenu()"
+    [attr.aria-expanded]="isMenuOpen()"
+    aria-controls="shell-menu"
+    aria-label="Abrir menu do jogador"
+  >
+    <span class="visually-hidden">Abrir menu do jogador</span>
+    <span class="menu-toggle__icon" aria-hidden="true">
+      <span></span>
+      <span></span>
+      <span></span>
+    </span>
+  </button>
   <div class="shell-header__brand">
     <span class="shell-header__logo" aria-hidden="true">HK</span>
     <div class="shell-header__titles">
@@ -8,11 +23,49 @@
       <p>Fluxo de trabalho épico com objetivos compartilhados.</p>
     </div>
   </div>
-  <nav class="shell-header__nav" aria-label="Menu principal">
-    <a routerLink="/" routerLinkActive="is-active" aria-current="page">Quadro</a>
-    <span class="shell-header__badge" aria-label="Nível da guilda">Lvl 5</span>
-  </nav>
+  <span class="shell-header__badge" aria-label="Nível atual da guilda">Lvl {{ experience().level }}</span>
 </header>
-<main class="shell-main" role="main">
-  <router-outlet></router-outlet>
-</main>
+<div class="shell-body">
+  <aside
+    id="shell-menu"
+    class="shell-menu"
+    role="complementary"
+    aria-label="Menu lateral do jogador"
+    [class.is-open]="isMenuOpen()"
+    [attr.aria-hidden]="!isMenuOpen()"
+    (keydown)="handleMenuKeydown($event)"
+  >
+    <header class="shell-menu__header">
+      <h2>Central do herói</h2>
+      <button type="button" class="menu-close" (click)="closeMenu()" aria-label="Fechar menu lateral">
+        <span aria-hidden="true">×</span>
+      </button>
+    </header>
+
+    <nav class="shell-menu__nav" aria-label="Navegação principal">
+      <h3>Navegação</h3>
+      <ul>
+        <li>
+          <a
+            routerLink="/"
+            routerLinkActive="is-active"
+            [routerLinkActiveOptions]="{ exact: true }"
+            (click)="closeMenu()"
+            >Quadro</a>
+        </li>
+        <li>
+          <a routerLink="/perfil" routerLinkActive="is-active" (click)="closeMenu()">Perfil</a>
+        </li>
+        <li>
+          <a routerLink="/quadro/personalizar" routerLinkActive="is-active" (click)="closeMenu()">
+            Editar quadro
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </aside>
+  <div class="shell-overlay" *ngIf="isMenuOpen()" (click)="closeMenu()" aria-hidden="true"></div>
+  <main class="shell-main" role="main">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -4,22 +4,76 @@
   min-height: 100vh;
   background: radial-gradient(circle at 10% 20%, #302b63 0%, #1c1a3b 40%, #0f0c29 100%);
   color: var(--hk-text-primary);
+  position: relative;
+  isolation: isolate;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .shell-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
   padding: 1.25rem clamp(1.5rem, 5vw, 3rem);
   backdrop-filter: blur(14px);
   background-color: rgba(16, 18, 32, 0.7);
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.menu-toggle:focus-visible,
+.menu-toggle:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.22);
+  transform: translateY(-1px);
+}
+
+.menu-toggle__icon {
+  display: grid;
+  gap: 0.35rem;
+  width: 1.5rem;
+}
+
+.menu-toggle__icon > span {
+  display: block;
+  height: 0.18rem;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform 0.3s ease;
 }
 
 .shell-header__brand {
   display: flex;
   align-items: center;
   gap: 1rem;
+  min-width: 0;
 }
 
 .shell-header__logo {
@@ -37,6 +91,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
+  min-width: 0;
 }
 
 .shell-header__titles > a {
@@ -44,34 +99,14 @@
   font-weight: 600;
   text-decoration: none;
   color: inherit;
+  white-space: nowrap;
 }
 
 .shell-header__titles > p {
   margin: 0;
   font-size: 0.95rem;
   color: var(--hk-text-muted);
-}
-
-.shell-header__nav {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  font-size: 0.95rem;
-}
-
-.shell-header__nav > a {
-  color: var(--hk-text-secondary);
-  text-decoration: none;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.shell-header__nav > a.is-active,
-.shell-header__nav > a:focus-visible,
-.shell-header__nav > a:hover {
-  color: #111120;
-  background-color: var(--hk-accent);
+  max-width: 28ch;
 }
 
 .shell-header__badge {
@@ -86,19 +121,140 @@
   letter-spacing: 0.04em;
 }
 
-.shell-main {
-  padding: clamp(1rem, 2.5vw, 2rem);
+.shell-body {
+  position: relative;
+  display: grid;
 }
 
-@media (max-width: 720px) {
-  .shell-header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
+.shell-menu {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: min(24rem, 92vw);
+  background: var(--hk-surface-elevated);
+  border-right: 1px solid var(--hk-border);
+  box-shadow: 0 0 48px rgba(12, 14, 31, 0.6);
+  transform: translateX(-110%);
+  transition: transform 0.3s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.shell-menu.is-open {
+  transform: translateX(0);
+}
+
+.shell-menu__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.shell-menu__header > h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.menu-close {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.menu-close:hover,
+.menu-close:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.24);
+}
+
+.shell-menu__nav {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shell-menu__nav > h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--hk-text-muted);
+}
+
+.shell-menu__nav ul {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.shell-menu__nav a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: var(--hk-text-secondary);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.shell-menu__nav a.is-active,
+.shell-menu__nav a:hover,
+.shell-menu__nav a:focus-visible {
+  background: rgba(124, 92, 255, 0.25);
+  border-color: rgba(124, 92, 255, 0.4);
+  color: #ffffff;
+}
+
+
+.shell-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 11, 25, 0.75);
+  backdrop-filter: blur(6px);
+  z-index: 8;
+}
+
+.shell-main {
+  padding: clamp(1rem, 2.5vw, 2rem);
+  position: relative;
+  z-index: 0;
+}
+
+@media (min-width: 960px) {
+  .menu-toggle {
+    width: 3rem;
+    height: 3rem;
   }
 
-  .shell-header__nav {
-    width: 100%;
-    justify-content: space-between;
+  .shell-menu {
+    width: min(26rem, 40vw);
+  }
+}
+
+@media (max-width: 600px) {
+  .shell-header {
+    align-items: flex-start;
+  }
+
+  .shell-header__badge {
+    align-self: flex-start;
   }
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -20,4 +20,17 @@ describe('AppComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.shell-header__titles a')?.textContent?.trim()).toBe('Hero Kanban');
   });
+
+  it('should toggle the lateral menu visibility', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.isMenuOpen()).toBeFalse();
+
+    component.toggleMenu();
+    expect(component.isMenuOpen()).toBeTrue();
+
+    component.closeMenu();
+    expect(component.isMenuOpen()).toBeFalse();
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,35 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { NgIf } from '@angular/common';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { HeroControlState } from './core/state/hero-control.state';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, NgIf],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class AppComponent {}
+export class AppComponent {
+  private readonly heroControl = inject(HeroControlState);
+
+  readonly isMenuOpen = signal(false);
+
+  readonly experience = this.heroControl.experience;
+  readonly experienceProgress = this.heroControl.experienceProgress;
+
+  toggleMenu(): void {
+    this.isMenuOpen.update((isOpen) => !isOpen);
+  }
+
+  closeMenu(): void {
+    this.isMenuOpen.set(false);
+  }
+
+  handleMenuKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.closeMenu();
+    }
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,6 +7,18 @@ export const routes: Routes = [
       import('./features/board/board.routes').then((m) => m.BOARD_ROUTES),
   },
   {
+    path: 'perfil',
+    loadChildren: () =>
+      import('./features/profile/profile.routes').then((m) => m.PROFILE_ROUTES),
+  },
+  {
+    path: 'quadro/personalizar',
+    loadChildren: () =>
+      import('./features/board-customizer/board-customizer.routes').then(
+        (m) => m.BOARD_CUSTOMIZER_ROUTES,
+      ),
+  },
+  {
     path: '**',
     redirectTo: '',
   },

--- a/src/app/core/state/hero-control.models.ts
+++ b/src/app/core/state/hero-control.models.ts
@@ -1,0 +1,26 @@
+export interface ProfileAchievement {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly progress: number;
+}
+
+export interface LootItem {
+  readonly id: string;
+  readonly name: string;
+  readonly quantity: number;
+  readonly rarity: 'comum' | 'raro' | 'lendário';
+}
+
+export interface BoardStatusOption {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly isActive: boolean;
+}
+
+export interface ExperienceSummary {
+  readonly level: number;
+  readonly current: number;
+  readonly nextLevel: number;
+}

--- a/src/app/core/state/hero-control.state.spec.ts
+++ b/src/app/core/state/hero-control.state.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { HeroControlState } from './hero-control.state';
+
+describe('HeroControlState', () => {
+  let state: HeroControlState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    state = TestBed.inject(HeroControlState);
+  });
+
+  it('should expose readonly slices of hero information', () => {
+    expect(state.experience().level).toBeGreaterThan(0);
+    expect(state.achievements().length).toBeGreaterThan(0);
+    expect(state.loot().length).toBeGreaterThan(0);
+  });
+
+  it('should add a custom status when the name is unique', () => {
+    state.updateNewStatusName('Exploração');
+    const initialLength = state.boardStatuses().length;
+
+    state.addCustomStatus();
+
+    const statuses = state.boardStatuses();
+    expect(statuses.length).toBe(initialLength + 1);
+    expect(statuses.some((item) => item.label === 'Exploração')).toBeTrue();
+  });
+
+  it('should avoid duplicating a status with the same label', () => {
+    const initialLength = state.boardStatuses().length;
+
+    state.updateNewStatusName('Backlog');
+    state.addCustomStatus();
+
+    expect(state.boardStatuses().length).toBe(initialLength);
+  });
+
+  it('should toggle a status active flag', () => {
+    const target = state.boardStatuses()[0];
+
+    state.toggleStatus(target.id, !target.isActive);
+
+    expect(state.boardStatuses()[0].isActive).toBe(!target.isActive);
+  });
+});

--- a/src/app/core/state/hero-control.state.ts
+++ b/src/app/core/state/hero-control.state.ts
@@ -1,0 +1,190 @@
+import { computed, Injectable, signal } from '@angular/core';
+import type {
+  BoardStatusOption,
+  ExperienceSummary,
+  LootItem,
+  ProfileAchievement,
+} from './hero-control.models';
+
+@Injectable({ providedIn: 'root' })
+export class HeroControlState {
+  private readonly _experience = signal<ExperienceSummary>({
+    level: 5,
+    current: 2480,
+    nextLevel: 3000,
+  });
+
+  private readonly _achievements = signal<ProfileAchievement[]>([
+    {
+      id: 'team-strategist',
+      title: 'Estrategista da Guilda',
+      description: 'Entregue 10 missões em sequência sem atrasos.',
+      progress: 72,
+    },
+    {
+      id: 'combo-master',
+      title: 'Combo Master',
+      description: 'Conclua 3 épicos no mesmo sprint.',
+      progress: 46,
+    },
+    {
+      id: 'guardian',
+      title: 'Guardião da Qualidade',
+      description: 'Zere o número de bugs críticos por duas semanas.',
+      progress: 88,
+    },
+  ]);
+
+  private readonly _loot = signal<LootItem[]>([
+    { id: 'phoenix-feather', name: 'Pena de Fênix', quantity: 2, rarity: 'raro' },
+    { id: 'ancient-coin', name: 'Moeda Arcana', quantity: 47, rarity: 'comum' },
+    { id: 'starlight-seal', name: 'Selo Luz das Estrelas', quantity: 1, rarity: 'lendário' },
+  ]);
+
+  private readonly _boardStatuses = signal<BoardStatusOption[]>([
+    {
+      id: 'backlog',
+      label: 'Backlog',
+      description: 'Ideias e missões futuras aguardando priorização.',
+      isActive: true,
+    },
+    {
+      id: 'in-progress',
+      label: 'Em andamento',
+      description: 'Missões que estão sendo executadas neste momento.',
+      isActive: true,
+    },
+    {
+      id: 'review',
+      label: 'Em revisão',
+      description: 'Missões aguardando validação pela guilda.',
+      isActive: true,
+    },
+    {
+      id: 'done',
+      label: 'Concluído',
+      description: 'Missões completadas e celebradas pela equipe.',
+      isActive: true,
+    },
+  ]);
+
+  private readonly _newStatusName = signal('');
+
+  readonly experience = this._experience.asReadonly();
+  readonly achievements = this._achievements.asReadonly();
+  readonly loot = this._loot.asReadonly();
+  readonly boardStatuses = this._boardStatuses.asReadonly();
+  readonly newStatusName = this._newStatusName.asReadonly();
+
+  readonly experienceProgress = computed(() => {
+    const { current, nextLevel } = this._experience();
+
+    if (nextLevel <= 0) {
+      return 0;
+    }
+
+    return Math.min(Math.round((current / nextLevel) * 100), 100);
+  });
+
+  readonly canCreateStatus = computed(() => {
+    const candidate = this._newStatusName().trim();
+
+    if (candidate.length < 3) {
+      return false;
+    }
+
+    const normalizedName = candidate.toLowerCase();
+    const baseId = this.buildStatusId(candidate);
+
+    return !this._boardStatuses().some(
+      (status) =>
+        status.id === baseId || status.label.toLowerCase() === normalizedName,
+    );
+  });
+
+  updateNewStatusName(value: string): void {
+    this._newStatusName.set(value);
+  }
+
+  addCustomStatus(): void {
+    if (!this.canCreateStatus()) {
+      return;
+    }
+
+    const name = this._newStatusName().trim();
+    const baseId = this.buildStatusId(name);
+    const uniqueId = this.resolveUniqueStatusId(baseId);
+    const label = this.capitalize(name);
+
+    this._boardStatuses.update((statuses) => [
+      ...statuses,
+      {
+        id: uniqueId,
+        label,
+        description: `Missões na etapa ${name.toLowerCase()}.`,
+        isActive: true,
+      },
+    ]);
+
+    this._newStatusName.set('');
+  }
+
+  toggleStatus(statusId: string, isActive: boolean): void {
+    this._boardStatuses.update((statuses) =>
+      statuses.map((status) =>
+        status.id === statusId ? { ...status, isActive } : status,
+      ),
+    );
+  }
+
+  trackAchievement(_: number, achievement: ProfileAchievement): string {
+    return achievement.id;
+  }
+
+  trackLoot(_: number, lootItem: LootItem): string {
+    return lootItem.id;
+  }
+
+  trackStatus(_: number, status: BoardStatusOption): string {
+    return status.id;
+  }
+
+  private buildStatusId(rawName: string): string {
+    const normalized = rawName
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    return normalized || 'status';
+  }
+
+  private resolveUniqueStatusId(baseId: string): string {
+    const statuses = this._boardStatuses();
+
+    if (!statuses.some((status) => status.id === baseId)) {
+      return baseId;
+    }
+
+    let suffix = 2;
+    let candidate = `${baseId}-${suffix}`;
+
+    while (statuses.some((status) => status.id === candidate)) {
+      suffix += 1;
+      candidate = `${baseId}-${suffix}`;
+    }
+
+    return candidate;
+  }
+
+  private capitalize(value: string): string {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return '';
+    }
+
+    return trimmed[0].toUpperCase() + trimmed.slice(1);
+  }
+}

--- a/src/app/features/board-customizer/README.md
+++ b/src/app/features/board-customizer/README.md
@@ -1,0 +1,16 @@
+# Feature: Personalização do quadro
+
+## Objetivo
+Permitir que a guilda adapte o fluxo de trabalho ativando ou criando novas etapas diretamente por meio de uma rota dedicada.
+
+## Decisões técnicas
+- Utilização do `HeroControlState` para manter as etapas sincronizadas entre o shell e a página de edição.
+- Componentização standalone com lazy-loading para evitar impacto no bundle inicial.
+
+## Exemplos de uso
+A rota `/quadro/personalizar` carrega `BoardCustomizerPageComponent`, que expõe toggles e formulário ligados ao estado compartilhado.
+
+## Checklist de manutenção
+- Cobrir novas ações com testes unitários no estado compartilhado.
+- Garantir acessibilidade das interações (foco e rótulos).
+- Revisar limites de performance ao ampliar o número de etapas.

--- a/src/app/features/board-customizer/board-customizer.routes.ts
+++ b/src/app/features/board-customizer/board-customizer.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+import { BoardCustomizerPageComponent } from './pages/board-customizer.page';
+
+export const BOARD_CUSTOMIZER_ROUTES: Routes = [
+  {
+    path: '',
+    component: BoardCustomizerPageComponent,
+  },
+];

--- a/src/app/features/board-customizer/pages/board-customizer.page.html
+++ b/src/app/features/board-customizer/pages/board-customizer.page.html
@@ -1,0 +1,56 @@
+<section class="board-customizer" aria-labelledby="board-customizer-heading">
+  <header class="board-customizer__header">
+    <div>
+      <h1 id="board-customizer-heading">Personalizar quadro</h1>
+      <p>Ative, reorganize e crie novas etapas para ajustar o fluxo às missões da guilda.</p>
+    </div>
+  </header>
+
+  <section class="board-customizer__statuses" aria-labelledby="status-list-heading">
+    <header>
+      <h2 id="status-list-heading">Etapas disponíveis</h2>
+      <p>Ative apenas os estágios relevantes para o ciclo atual.</p>
+    </header>
+    <ul>
+      <li *ngFor="let status of statuses(); trackBy: trackStatus">
+        <label class="status-toggle">
+          <input
+            type="checkbox"
+            [checked]="status.isActive"
+            (change)="onStatusToggle(status.id, $event)"
+            [attr.aria-label]="'Alternar etapa ' + status.label"
+          />
+          <span class="status-toggle__body">
+            <span class="status-toggle__label">{{ status.label }}</span>
+            <span class="status-toggle__description">{{ status.description }}</span>
+          </span>
+        </label>
+      </li>
+    </ul>
+  </section>
+
+  <section class="board-customizer__create" aria-labelledby="status-create-heading">
+    <header>
+      <h2 id="status-create-heading">Criar nova etapa</h2>
+      <p>Use nomes únicos com pelo menos três caracteres para manter o fluxo organizado.</p>
+    </header>
+    <form (submit)="onStatusFormSubmit($event)" aria-label="Criar nova etapa do quadro">
+      <label class="status-form__label" for="new-status">Nome da etapa</label>
+      <div class="status-form__controls">
+        <input
+          id="new-status"
+          type="text"
+          name="new-status"
+          placeholder="Ex.: Em validação"
+          autocomplete="off"
+          [value]="newStatusName()"
+          (input)="onStatusNameInput($event)"
+        />
+        <button type="submit" [disabled]="!canCreateStatus()">Adicionar</button>
+      </div>
+      <p class="status-form__hint" *ngIf="!canCreateStatus()">
+        Informe um nome exclusivo com pelo menos 3 caracteres.
+      </p>
+    </form>
+  </section>
+</section>

--- a/src/app/features/board-customizer/pages/board-customizer.page.scss
+++ b/src/app/features/board-customizer/pages/board-customizer.page.scss
@@ -1,0 +1,162 @@
+:host {
+  display: block;
+  color: var(--hk-text-primary);
+}
+
+.board-customizer {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  background: rgba(13, 16, 34, 0.85);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 24px 56px rgba(10, 12, 28, 0.45);
+}
+
+.board-customizer__header h1 {
+  margin: 0;
+  font-size: clamp(1.7rem, 3vw, 2.2rem);
+}
+
+.board-customizer__header p {
+  margin: 0.35rem 0 0;
+  color: var(--hk-text-muted);
+  max-width: 50ch;
+}
+
+.board-customizer__statuses,
+.board-customizer__create {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.board-customizer__statuses > header,
+.board-customizer__create > header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.board-customizer__statuses h2,
+.board-customizer__create h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.board-customizer__statuses p,
+.board-customizer__create p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.board-customizer__statuses ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.status-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+  cursor: pointer;
+}
+
+.status-toggle:hover,
+.status-toggle:focus-within {
+  border-color: rgba(124, 92, 255, 0.45);
+  background: rgba(124, 92, 255, 0.16);
+}
+
+.status-toggle input {
+  margin-top: 0.2rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #7c5cff;
+}
+
+.status-toggle__body {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.status-toggle__label {
+  font-weight: 600;
+}
+
+.status-toggle__description {
+  color: var(--hk-text-muted);
+  font-size: 0.95rem;
+}
+
+.status-form__label {
+  font-weight: 600;
+}
+
+.status-form__controls {
+  display: flex;
+  gap: 0.85rem;
+}
+
+.status-form__controls input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(8, 8, 18, 0.5);
+  color: inherit;
+}
+
+.status-form__controls input:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.status-form__controls button {
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.9rem;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, #7c5cff 0%, #4f46e5 100%);
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.status-form__controls button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.4);
+  opacity: 0.65;
+}
+
+.status-form__controls button:not(:disabled):hover,
+.status-form__controls button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.status-form__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--hk-text-muted);
+}
+
+@media (max-width: 720px) {
+  .board-customizer {
+    padding: clamp(1rem, 6vw, 2rem);
+  }
+
+  .status-form__controls {
+    flex-direction: column;
+  }
+
+  .status-form__controls button {
+    width: 100%;
+  }
+}

--- a/src/app/features/board-customizer/pages/board-customizer.page.ts
+++ b/src/app/features/board-customizer/pages/board-customizer.page.ts
@@ -1,0 +1,49 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { HeroControlState } from '@app/core/state/hero-control.state';
+import type { BoardStatusOption } from '@app/core/state/hero-control.models';
+
+@Component({
+  selector: 'hk-board-customizer-page',
+  standalone: true,
+  templateUrl: './board-customizer.page.html',
+  styleUrls: ['./board-customizer.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgFor, NgIf],
+})
+export class BoardCustomizerPageComponent {
+  private readonly heroControl = inject(HeroControlState);
+
+  protected readonly statuses = this.heroControl.boardStatuses;
+  protected readonly newStatusName = this.heroControl.newStatusName;
+  protected readonly canCreateStatus = this.heroControl.canCreateStatus;
+
+  protected trackStatus(_: number, status: BoardStatusOption): string {
+    return status.id;
+  }
+
+  protected onStatusToggle(statusId: string, event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    this.heroControl.toggleStatus(statusId, target.checked);
+  }
+
+  protected onStatusNameInput(event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    this.heroControl.updateNewStatusName(target.value);
+  }
+
+  protected onStatusFormSubmit(event: Event): void {
+    event.preventDefault();
+    this.heroControl.addCustomStatus();
+  }
+}

--- a/src/app/features/profile/README.md
+++ b/src/app/features/profile/README.md
@@ -1,0 +1,16 @@
+# Feature: Perfil do herói
+
+## Objetivo
+Oferecer uma visão consolidada do progresso do jogador dentro do Hero Kanban, destacando nível, conquistas e recompensas desbloqueadas.
+
+## Decisões técnicas
+- Consumo do estado compartilhado por meio do `HeroControlState`, garantindo consistência entre shell, perfil e demais rotas.
+- Componentização standalone para facilitar lazy-loading e isolamento de estilos.
+
+## Exemplos de uso
+A rota `/perfil` carrega `ProfilePageComponent`, que lê sinais somente-leitura do estado compartilhado.
+
+## Checklist de manutenção
+- Atualizar testes do estado sempre que adicionar novas ações.
+- Validar contraste dos cartões de conquistas e loots.
+- Manter cópia das strings em i18n quando a camada for introduzida.

--- a/src/app/features/profile/pages/profile.page.html
+++ b/src/app/features/profile/pages/profile.page.html
@@ -1,0 +1,57 @@
+<section class="profile" aria-labelledby="profile-heading">
+  <header class="profile__header">
+    <div>
+      <h1 id="profile-heading">Perfil do herói</h1>
+      <p>Consulte o progresso, conquistas e recompensas desbloqueadas pela guilda.</p>
+    </div>
+    <span class="profile__level" aria-label="Nível atual">Lvl {{ experience().level }}</span>
+  </header>
+
+  <section class="profile__xp" aria-labelledby="xp-heading">
+    <h2 id="xp-heading">Experiência acumulada</h2>
+    <p>
+      <strong>{{ experience().current | number: '1.0-0' }}</strong>
+      de {{ experience().nextLevel | number: '1.0-0' }} XP para o próximo nível.
+    </p>
+    <div class="profile__xp-progress" role="img" [attr.aria-label]="'Progresso de experiência em ' + experienceProgress() + '%'">
+      <div class="profile__xp-bar" [style.width.%]="experienceProgress()"></div>
+    </div>
+  </section>
+
+  <section class="profile__achievements" aria-labelledby="achievements-heading">
+    <header>
+      <h2 id="achievements-heading">Conquistas desbloqueadas</h2>
+      <p>Meta conquistas colaborativas para liberar novos cosméticos e títulos.</p>
+    </header>
+    <ul>
+      <li *ngFor="let achievement of achievements(); trackBy: trackAchievement">
+        <article class="achievement-card" [attr.aria-label]="'Conquista ' + achievement.title">
+          <header>
+            <span class="achievement-card__icon" aria-hidden="true">★</span>
+            <div>
+              <p class="achievement-card__title">{{ achievement.title }}</p>
+              <p class="achievement-card__description">{{ achievement.description }}</p>
+            </div>
+          </header>
+          <div class="achievement-card__progress" role="img" [attr.aria-label]="'Progresso ' + achievement.progress + '%'">
+            <div class="achievement-card__progress-bar" [style.width.%]="achievement.progress"></div>
+          </div>
+          <span class="achievement-card__value">{{ achievement.progress }}%</span>
+        </article>
+      </li>
+    </ul>
+  </section>
+
+  <section class="profile__loot" aria-labelledby="loot-heading">
+    <header>
+      <h2 id="loot-heading">Inventário de loots</h2>
+      <p>Itens raros conquistados em desafios recentes da guilda.</p>
+    </header>
+    <ul>
+      <li *ngFor="let item of loot(); trackBy: trackLoot" [attr.data-rarity]="item.rarity">
+        <span class="loot-card__name">{{ item.name }}</span>
+        <span class="loot-card__quantity">×{{ item.quantity }}</span>
+      </li>
+    </ul>
+  </section>
+</section>

--- a/src/app/features/profile/pages/profile.page.scss
+++ b/src/app/features/profile/pages/profile.page.scss
@@ -1,0 +1,204 @@
+:host {
+  display: block;
+  color: var(--hk-text-primary);
+}
+
+.profile {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  background: rgba(13, 16, 34, 0.8);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 28px 60px rgba(10, 12, 28, 0.45);
+}
+
+.profile__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.profile__header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.3rem);
+}
+
+.profile__header p {
+  margin: 0.35rem 0 0;
+  color: var(--hk-text-muted);
+  max-width: 48ch;
+}
+
+.profile__level {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.8), rgba(79, 70, 229, 0.8));
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.profile__xp {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.profile__xp h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.profile__xp p {
+  margin: 0;
+  color: var(--hk-text-secondary);
+}
+
+.profile__xp-progress {
+  position: relative;
+  height: 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.profile__xp-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7c5cff 0%, #00d4ff 100%);
+}
+
+.profile__achievements,
+.profile__loot {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.profile__achievements > header,
+.profile__loot > header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.profile__achievements > header h2,
+.profile__loot > header h2 {
+  margin: 0;
+}
+
+.profile__achievements > header p,
+.profile__loot > header p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.profile__achievements ul,
+.profile__loot ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.achievement-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.achievement-card > header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.achievement-card__icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.9rem;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, #facc15, #f97316);
+  color: #16121f;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.achievement-card__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.achievement-card__description {
+  margin: 0.25rem 0 0;
+  color: var(--hk-text-muted);
+  font-size: 0.95rem;
+}
+
+.achievement-card__progress {
+  position: relative;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.achievement-card__progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #34d399 0%, #22d3ee 100%);
+}
+
+.achievement-card__value {
+  justify-self: end;
+  font-size: 0.9rem;
+  color: var(--hk-text-muted);
+}
+
+.profile__loot li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 1rem;
+}
+
+.profile__loot li[data-rarity='raro'] {
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+.profile__loot li[data-rarity='lendário'] {
+  border-color: rgba(250, 204, 21, 0.6);
+  box-shadow: 0 0 14px rgba(250, 204, 21, 0.24);
+}
+
+.loot-card__name {
+  font-weight: 600;
+}
+
+.loot-card__quantity {
+  color: var(--hk-text-muted);
+}
+
+@media (max-width: 720px) {
+  .profile {
+    padding: clamp(1rem, 6vw, 2rem);
+  }
+
+  .profile__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/app/features/profile/pages/profile.page.ts
+++ b/src/app/features/profile/pages/profile.page.ts
@@ -1,0 +1,28 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { DecimalPipe, NgFor } from '@angular/common';
+import { HeroControlState } from '@app/core/state/hero-control.state';
+import type { LootItem, ProfileAchievement } from '@app/core/state/hero-control.models';
+
+@Component({
+  selector: 'hk-profile-page',
+  standalone: true,
+  templateUrl: './profile.page.html',
+  styleUrls: ['./profile.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgFor, DecimalPipe],
+})
+export class ProfilePageComponent {
+  private readonly heroControl = inject(HeroControlState);
+
+  protected readonly experience = this.heroControl.experience;
+  protected readonly experienceProgress = this.heroControl.experienceProgress;
+  protected readonly achievements = this.heroControl.achievements;
+  protected readonly loot = this.heroControl.loot;
+  protected trackAchievement(_: number, achievement: ProfileAchievement): string {
+    return achievement.id;
+  }
+
+  protected trackLoot(_: number, lootItem: LootItem): string {
+    return lootItem.id;
+  }
+}

--- a/src/app/features/profile/profile.routes.ts
+++ b/src/app/features/profile/profile.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+import { ProfilePageComponent } from './pages/profile.page';
+
+export const PROFILE_ROUTES: Routes = [
+  {
+    path: '',
+    component: ProfilePageComponent,
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,14 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022"
+    "module": "ES2022",
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": ["app/*"],
+      "@core/*": ["app/core/*"],
+      "@shared/*": ["app/shared/*"],
+      "@features/*": ["app/features/*"]
+    }
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
## Summary
- create a shared hero control state to expose profile metrics, loot and board stages across routes
- add lazy-loaded `/perfil` and `/quadro/personalizar` pages with dedicated profile and board customization UIs
- simplify the shell menu to navigation links and configure TypeScript path aliases for feature imports

## Testing
- CI=1 npm run test -- --watch=false *(fails: Chrome browser binary not available in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc29c9a6083339c9c6f027735c81e