### PR TITLE
Fix board page height and scrolling

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -124,6 +124,7 @@
 .shell-body {
   position: relative;
   display: grid;
+  min-height: 0;
 }
 
 .shell-menu {
@@ -236,6 +237,11 @@
   padding: clamp(1rem, 2.5vw, 2rem);
   position: relative;
   z-index: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 @media (min-width: 960px) {

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -1,8 +1,17 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .board {
   display: flex;
   flex-direction: column;
   gap: 2rem;
   color: var(--hk-text-primary);
+  flex: 1;
+  min-height: 0;
 }
 
 .board__header {
@@ -14,6 +23,7 @@
   padding: clamp(1.25rem, 3vw, 2rem);
   border-radius: 1.5rem;
   box-shadow: 0 25px 50px -12px rgba(15, 12, 41, 0.4);
+  flex: 0 0 auto;
 }
 
 .board__intro > h1 {
@@ -159,10 +169,12 @@
   gap: 1.25rem;
   align-items: stretch;
   overflow-x: auto;
+  overflow-y: auto;
   padding-bottom: 0.75rem;
   padding-right: 0.5rem;
   scroll-snap-type: x proximity;
-  min-height: 60vh;
+  flex: 1;
+  min-height: 0;
 }
 
 .board__columns > kanban-board-column {


### PR DESCRIPTION
## Summary
- allow the application shell to stretch the main outlet to the viewport and hide the outer scroll
- make the board page occupy the available height and let the columns region handle scrolling within the viewport

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ddc7e8bbc8833396ed837309c2a96c