### PR TITLE
feat: allow creating stories with tasks from the board

### DIFF
--- a/src/app/features/board/README.md
+++ b/src/app/features/board/README.md
@@ -20,6 +20,11 @@ Rotas lazy-loaded já expõem a `BoardPage`. Componentes podem ser reutilizados 
 ## Dependências externas
 - Nenhuma dependência adicional além do Angular padrão. Fontes Google (Inter e Material Symbols) são carregadas no `index.html` para reforçar a estética gamificada.
 
+## Cadastro de histórias
+- O botão **Nova história** abre o modal standalone `CreateStoryModalComponent`, reunindo dados da missão (título, feature, status, prioridade, responsável, XP e etiquetas) no mesmo visual neon futurista do quadro.
+- As tarefas inseridas no modal tornam-se `StoryTask` tipadas no `BoardState`, alimentando automaticamente o checklist exibido em cada `BoardCard`.
+- O estado valida limites de WIP antes de persistir a nova história; etapas saturadas aparecem desabilitadas no seletor do modal.
+
 ## Checklist de manutenção
 - [ ] Atualizar mocks em `BoardState` ao integrar API real.
 - [ ] Revisar acessibilidade (aria-grabbed, mensagens) quando ampliar a interação de drag-and-drop.

--- a/src/app/features/board/components/create-story-modal/create-story-modal.component.html
+++ b/src/app/features/board/components/create-story-modal/create-story-modal.component.html
@@ -1,0 +1,148 @@
+<section class="create-story-modal" (keydown.escape)="onCancel()">
+  <div class="create-story-modal__backdrop" (click)="onCancel()" aria-hidden="true"></div>
+  <div
+    class="create-story-modal__panel"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="create-story-title"
+  >
+    <form class="create-story-modal__form" (ngSubmit)="onSubmit()" novalidate>
+      <header class="create-story-modal__header">
+        <div>
+          <h2 id="create-story-title">Cadastrar nova história</h2>
+          <p>
+            Conecte uma missão a atividades detalhadas, defina prioridade e acompanhe o progresso da guilda.
+          </p>
+        </div>
+        <button type="button" class="create-story-modal__close" (click)="onCancel()" aria-label="Fechar modal">
+          <span class="material-symbols-rounded" aria-hidden="true">close</span>
+        </button>
+      </header>
+
+      <div class="create-story-modal__grid">
+        <label class="create-story-modal__field">
+          <span>Título da história</span>
+          <input type="text" formControlName="title" placeholder="Ex.: Portal de crafting cooperativo" />
+          <small *ngIf="form.controls.title.invalid && form.controls.title.touched">
+            Informe um título com pelo menos 3 caracteres.
+          </small>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Feature relacionada</span>
+          <select formControlName="featureId">
+            <option value="" disabled>Selecione uma feature</option>
+            <option *ngFor="let feature of features()" [value]="feature.id">{{ feature.title }}</option>
+          </select>
+          <small *ngIf="form.controls.featureId.invalid && form.controls.featureId.touched">
+            Escolha a feature que receberá a nova história.
+          </small>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Etapa do fluxo</span>
+          <select formControlName="statusId">
+            <option value="" disabled>Selecione a etapa</option>
+            <option
+              *ngFor="let option of statusOptions()"
+              [value]="option.status.id"
+              [disabled]="option.isAtLimit"
+            >
+              {{ option.status.name }} · {{ option.wipCount }} / {{ option.wipLimit ?? '∞' }} WIP
+            </option>
+          </select>
+          <small *ngIf="statusAtCapacity()">A etapa selecionada está no limite de WIP.</small>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Prioridade</span>
+          <select formControlName="priority">
+            <option *ngFor="let option of priorityOptions" [value]="option.value">{{ option.label }}</option>
+          </select>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Estimativa (story points)</span>
+          <input type="number" min="1" formControlName="estimate" />
+          <small *ngIf="form.controls.estimate.invalid && form.controls.estimate.touched">
+            Utilize um valor maior ou igual a 1.
+          </small>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Responsável</span>
+          <input type="text" formControlName="assignee" placeholder="Ex.: Joana Silva" />
+          <small *ngIf="form.controls.assignee.invalid && form.controls.assignee.touched">
+            Informe quem liderará a missão.
+          </small>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Etiquetas</span>
+          <input type="text" formControlName="labels" placeholder="Ex.: Backend, Integrations" />
+          <small>Separe etiquetas com vírgula.</small>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Recompensa de XP</span>
+          <input type="number" min="1" formControlName="xp" />
+          <small *ngIf="form.controls.xp.invalid && form.controls.xp.touched">
+            Utilize um valor maior ou igual a 1 XP.
+          </small>
+        </label>
+
+        <label class="create-story-modal__field">
+          <span>Data alvo</span>
+          <input type="date" formControlName="dueDate" />
+        </label>
+      </div>
+
+      <section class="create-story-modal__tasks" aria-labelledby="tasks-heading">
+        <header>
+          <h3 id="tasks-heading">Atividades da guilda</h3>
+          <p>Detalhe as subtarefas que desbloqueiam XP. Marque as que já estão concluídas.</p>
+        </header>
+
+        <div class="create-story-modal__tasks-list" formArrayName="tasks">
+          <article
+            class="create-story-modal__task"
+            *ngFor="let taskGroup of taskArray.controls; let index = index; trackBy: trackTask"
+            [formGroupName]="index"
+          >
+            <label>
+              <span>Descrição da tarefa</span>
+              <input type="text" formControlName="title" placeholder="Ex.: Configurar telemetria de XP" />
+            </label>
+            <div class="create-story-modal__task-actions">
+              <label class="create-story-modal__checkbox">
+                <input type="checkbox" formControlName="isDone" />
+                <span>Concluída</span>
+              </label>
+              <button type="button" (click)="removeTask(index)" aria-label="Remover tarefa">
+                <span class="material-symbols-rounded" aria-hidden="true">delete</span>
+              </button>
+            </div>
+            <small *ngIf="taskGroup.controls.title.invalid && taskGroup.controls.title.touched">
+              Descreva a atividade com pelo menos 3 caracteres.
+            </small>
+          </article>
+          <p *ngIf="taskArray.length === 0" class="create-story-modal__tasks-empty">
+            Nenhuma atividade adicionada ainda. Inclua tarefas para orientar o squad.
+          </p>
+        </div>
+
+        <button type="button" class="create-story-modal__add-task" (click)="addTask()">
+          <span class="material-symbols-rounded" aria-hidden="true">add</span>
+          Adicionar tarefa
+        </button>
+      </section>
+
+      <footer class="create-story-modal__footer">
+        <button type="button" class="create-story-modal__secondary" (click)="onCancel()">Cancelar</button>
+        <button type="submit" class="create-story-modal__primary" [disabled]="form.invalid || statusAtCapacity()">
+          Salvar história
+        </button>
+      </footer>
+    </form>
+  </div>
+</section>

--- a/src/app/features/board/components/create-story-modal/create-story-modal.component.scss
+++ b/src/app/features/board/components/create-story-modal/create-story-modal.component.scss
@@ -1,0 +1,294 @@
+.create-story-modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+}
+
+.create-story-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 6, 20, 0.75);
+  backdrop-filter: blur(8px);
+}
+
+.create-story-modal__panel {
+  position: relative;
+  width: min(720px, calc(100vw - 2rem));
+  max-height: calc(100vh - 3rem);
+  overflow: auto;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(145deg, rgba(24, 22, 54, 0.95), rgba(16, 18, 42, 0.95));
+  box-shadow: 0 30px 80px rgba(8, 9, 29, 0.65);
+}
+
+.create-story-modal__form {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  color: var(--hk-text-primary);
+}
+
+.create-story-modal__header {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.create-story-modal__header h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+}
+
+.create-story-modal__header p {
+  margin: 0.5rem 0 0;
+  color: var(--hk-text-muted);
+  max-width: 46ch;
+}
+
+.create-story-modal__close {
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-items: center;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.create-story-modal__close:hover,
+.create-story-modal__close:focus-visible {
+  background: rgba(255, 255, 255, 0.14);
+  transform: scale(1.05);
+}
+
+.create-story-modal__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.create-story-modal__field {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.create-story-modal__field > span {
+  font-weight: 600;
+}
+
+.create-story-modal__field input,
+.create-story-modal__field select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(14, 16, 38, 0.75);
+  color: inherit;
+  font: inherit;
+}
+
+.create-story-modal__field input:focus-visible,
+.create-story-modal__field select:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.create-story-modal__field small {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
+}
+
+.create-story-modal__field small.ng-star-inserted {
+  color: #fbbf24;
+}
+
+.create-story-modal__tasks {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.create-story-modal__tasks > header {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.create-story-modal__tasks h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.create-story-modal__tasks p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.create-story-modal__tasks-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.create-story-modal__task {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(124, 92, 255, 0.2);
+  background: rgba(124, 92, 255, 0.08);
+}
+
+.create-story-modal__task label {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.create-story-modal__task small {
+  color: #fbbf24;
+  font-size: 0.8rem;
+}
+
+.create-story-modal__task input[type='text'] {
+  padding: 0.7rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(10, 12, 28, 0.75);
+  color: inherit;
+}
+
+.create-story-modal__task input[type='text']:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.create-story-modal__task-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.create-story-modal__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.create-story-modal__checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #7c5cff;
+}
+
+.create-story-modal__task-actions button {
+  border: none;
+  background: rgba(248, 113, 113, 0.18);
+  color: #fca5a5;
+  border-radius: 999px;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.create-story-modal__task-actions button:hover,
+.create-story-modal__task-actions button:focus-visible {
+  background: rgba(248, 113, 113, 0.3);
+  transform: scale(1.05);
+}
+
+.create-story-modal__tasks-empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  color: var(--hk-text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.create-story-modal__add-task {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.9), rgba(79, 70, 229, 0.9));
+  color: #ffffff;
+  cursor: pointer;
+  width: fit-content;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.create-story-modal__add-task:hover,
+.create-story-modal__add-task:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.create-story-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.create-story-modal__secondary {
+  padding: 0.85rem 1.4rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  color: var(--hk-text-primary);
+  cursor: pointer;
+}
+
+.create-story-modal__secondary:hover,
+.create-story-modal__secondary:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.create-story-modal__primary {
+  padding: 0.9rem 1.6rem;
+  border-radius: 0.9rem;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, #7c5cff 0%, #4f46e5 100%);
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.create-story-modal__primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+}
+
+.create-story-modal__primary:not(:disabled):hover,
+.create-story-modal__primary:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+@media (max-width: 640px) {
+  .create-story-modal__header {
+    flex-direction: column;
+  }
+
+  .create-story-modal__footer {
+    flex-direction: column;
+  }
+
+  .create-story-modal__footer button {
+    width: 100%;
+  }
+}

--- a/src/app/features/board/components/create-story-modal/create-story-modal.component.ts
+++ b/src/app/features/board/components/create-story-modal/create-story-modal.component.ts
@@ -1,0 +1,166 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import {
+  FormArray,
+  FormControl,
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import type {
+  BoardStatusWithCapacity,
+  CreateStoryPayload,
+  Feature,
+  Priority,
+} from '../../state/board.models';
+
+interface StoryTaskForm {
+  readonly title: FormControl<string>;
+  readonly isDone: FormControl<boolean>;
+}
+
+type StoryTaskFormGroup = FormGroup<StoryTaskForm>;
+
+@Component({
+  selector: 'kanban-create-story-modal',
+  standalone: true,
+  templateUrl: './create-story-modal.component.html',
+  styleUrls: ['./create-story-modal.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgFor, NgIf, ReactiveFormsModule],
+})
+export class CreateStoryModalComponent {
+  readonly features = input.required<readonly Feature[]>();
+  readonly statusOptions = input.required<readonly BoardStatusWithCapacity[]>();
+
+  readonly dismissed = output<void>();
+  readonly submitted = output<CreateStoryPayload>();
+
+  protected readonly priorityOptions: ReadonlyArray<{ value: Priority; label: string }> = [
+    { value: 'critical', label: 'Crítica' },
+    { value: 'high', label: 'Alta' },
+    { value: 'medium', label: 'Média' },
+    { value: 'low', label: 'Baixa' },
+  ];
+
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+
+  protected readonly form = this.formBuilder.group({
+    title: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    featureId: this.formBuilder.control('', Validators.required),
+    statusId: this.formBuilder.control('', Validators.required),
+    priority: this.formBuilder.control<Priority>('medium', Validators.required),
+    estimate: this.formBuilder.control(3, { validators: [Validators.required, Validators.min(1)] }),
+    assignee: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    labels: this.formBuilder.control(''),
+    xp: this.formBuilder.control(40, { validators: [Validators.required, Validators.min(1)] }),
+    dueDate: this.formBuilder.control(''),
+    tasks: this.formBuilder.array<StoryTaskFormGroup>([]),
+  });
+
+  protected readonly statusAtCapacity = computed(() => {
+    const currentStatusId = this.form.controls.statusId.value;
+    const option = this.statusOptions().find((item) => item.status.id === currentStatusId);
+    return option?.isAtLimit ?? false;
+  });
+
+  private readonly syncDefaultsEffect = effect(
+    () => {
+      const featureOptions = this.features();
+      const statusOptions = this.statusOptions();
+
+      if (featureOptions.length > 0 && this.form.controls.featureId.value === '') {
+        this.form.controls.featureId.setValue(featureOptions[0].id);
+      }
+
+      const currentStatusId = this.form.controls.statusId.value;
+      if (currentStatusId === '' && statusOptions.length > 0) {
+        const firstAvailable = statusOptions.find((option) => !option.isAtLimit) ?? statusOptions[0];
+        this.form.controls.statusId.setValue(firstAvailable.status.id);
+      }
+    },
+    { allowSignalWrites: true },
+  );
+
+  protected get taskArray(): FormArray<StoryTaskFormGroup> {
+    return this.form.controls.tasks;
+  }
+
+  protected trackTask(index: number): number {
+    return index;
+  }
+
+  protected addTask(): void {
+    this.taskArray.push(this.createTaskGroup());
+  }
+
+  protected removeTask(index: number): void {
+    this.taskArray.removeAt(index);
+  }
+
+  protected onCancel(): void {
+    this.dismissed.emit();
+    this.resetForm();
+  }
+
+  protected onSubmit(): void {
+    if (this.form.invalid || this.statusAtCapacity()) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const value = this.form.getRawValue();
+    const payload: CreateStoryPayload = {
+      title: value.title,
+      featureId: value.featureId,
+      statusId: value.statusId,
+      priority: value.priority,
+      estimate: value.estimate,
+      assignee: value.assignee,
+      labels: value.labels
+        .split(',')
+        .map((label) => label.trim())
+        .filter((label) => label.length > 0),
+      xp: value.xp,
+      dueDate: value.dueDate ? new Date(value.dueDate).toISOString() : undefined,
+      tasks: value.tasks.map((task) => ({
+        title: task.title,
+        isDone: task.isDone,
+      })),
+    } satisfies CreateStoryPayload;
+
+    this.submitted.emit(payload);
+    this.resetForm();
+  }
+
+  private resetForm(): void {
+    this.form.reset({
+      title: '',
+      featureId: '',
+      statusId: '',
+      priority: 'medium',
+      estimate: 3,
+      assignee: '',
+      labels: '',
+      xp: 40,
+      dueDate: '',
+    });
+    this.taskArray.clear();
+  }
+
+  private createTaskGroup(): StoryTaskFormGroup {
+    return this.formBuilder.group({
+      title: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+      isDone: this.formBuilder.control(false),
+    });
+  }
+}

--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -1,8 +1,14 @@
 <section class="board" aria-labelledby="board-heading">
   <header class="board__header">
     <div class="board__intro">
-      <h1 id="board-heading">Missões em andamento</h1>
-      <p>Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.</p>
+      <div class="board__intro-text">
+        <h1 id="board-heading">Missões em andamento</h1>
+        <p>Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.</p>
+      </div>
+      <button type="button" class="board__new-story" (click)="openCreateStory()">
+        <span class="material-symbols-rounded" aria-hidden="true">add_circle</span>
+        Nova história
+      </button>
     </div>
     <div class="board__progress" role="status" aria-live="polite">
       <div class="board__level">Guilda nível {{ summary().level }}</div>
@@ -59,4 +65,12 @@
       role="listitem"
     ></kanban-board-column>
   </section>
+
+  <kanban-create-story-modal
+    *ngIf="isCreatingStory()"
+    [features]="features()"
+    [statusOptions]="statusOptions()"
+    (dismissed)="closeCreateStory()"
+    (submitted)="onStorySubmitted($event)"
+  ></kanban-create-story-modal>
 </section>

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -26,15 +26,57 @@
   flex: 0 0 auto;
 }
 
-.board__intro > h1 {
+.board__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.board__intro-text > h1 {
   margin: 0;
   font-size: clamp(1.6rem, 2.8vw, 2.4rem);
   font-weight: 700;
 }
 
-.board__intro > p {
+.board__intro-text > p {
   margin: 0.4rem 0 0;
   color: var(--hk-text-muted);
+}
+
+@media (min-width: 720px) {
+  .board__intro {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 719px) {
+  .board__new-story {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+.board__new-story {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #7c5cff 0%, #4f46e5 100%);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.board__new-story:hover,
+.board__new-story:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
 }
 
 .board__progress {

--- a/src/app/features/board/pages/board.page.ts
+++ b/src/app/features/board/pages/board.page.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { DecimalPipe, NgFor, NgIf } from '@angular/common';
-import type { BoardColumnViewModel } from '../state/board.models';
+import type { BoardColumnViewModel, CreateStoryPayload } from '../state/board.models';
 import { BoardState } from '../state/board-state.service';
 import { BoardColumnComponent } from '../components/board-column/board-column.component';
+import { CreateStoryModalComponent } from '../components/create-story-modal/create-story-modal.component';
 
 @Component({
   selector: 'hk-board-page',
@@ -10,15 +11,33 @@ import { BoardColumnComponent } from '../components/board-column/board-column.co
   templateUrl: './board.page.html',
   styleUrls: ['./board.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, NgIf, DecimalPipe, BoardColumnComponent],
+  imports: [NgFor, NgIf, DecimalPipe, BoardColumnComponent, CreateStoryModalComponent],
 })
 export class BoardPageComponent {
   private readonly boardState = inject(BoardState);
 
   protected readonly columns = this.boardState.columns;
   protected readonly summary = this.boardState.summary;
+  protected readonly features = this.boardState.features;
+  protected readonly statusOptions = this.boardState.statusOptions;
+  protected readonly isCreatingStory = signal(false);
 
   protected trackColumn(_: number, column: BoardColumnViewModel): string {
     return column.status.id;
+  }
+
+  protected openCreateStory(): void {
+    this.isCreatingStory.set(true);
+  }
+
+  protected closeCreateStory(): void {
+    this.isCreatingStory.set(false);
+  }
+
+  protected onStorySubmitted(draft: CreateStoryPayload): void {
+    const created = this.boardState.createStory(draft);
+    if (created) {
+      this.isCreatingStory.set(false);
+    }
   }
 }

--- a/src/app/features/board/state/board-state.service.spec.ts
+++ b/src/app/features/board/state/board-state.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { BoardState } from './board-state.service';
+import type { CreateStoryPayload } from './board.models';
 
 describe('BoardState', () => {
   let service: BoardState;
@@ -35,5 +36,56 @@ describe('BoardState', () => {
 
     service.moveStory('story-mission-engine', 'release');
     expect(service.canMoveStory('story-onboarding', 'release')).toBeFalse();
+  });
+
+  it('should create stories with checklist progress derived from tasks', () => {
+    const draft: CreateStoryPayload = {
+      title: 'Central de alinhamento da guilda',
+      featureId: 'feat-progress-graph',
+      statusId: 'backlog',
+      priority: 'high',
+      estimate: 5,
+      assignee: 'Bianca Torres',
+      labels: ['Discovery', 'Facilitação'],
+      xp: 55,
+      tasks: [
+        { title: 'Planejar workshop de ritos', isDone: true },
+        { title: 'Consolidar insights da guilda', isDone: false },
+      ],
+    };
+
+    const created = service.createStory(draft);
+    expect(created).not.toBeNull();
+
+    const backlogColumn = service.columns().find((column) => column.status.id === 'backlog');
+    expect(backlogColumn).toBeDefined();
+
+    const createdCard = backlogColumn?.cards.find((card) => card.id === created?.id);
+    expect(createdCard).toBeDefined();
+    expect(createdCard?.checklistProgressLabel).toBe('1/2 checklist');
+  });
+
+  it('should block story creation when WIP limit is reached', () => {
+    const baseDraft: CreateStoryPayload = {
+      title: 'Deploy sincronizado com comunidade',
+      featureId: 'feat-guild-rewards',
+      statusId: 'release',
+      priority: 'medium',
+      estimate: 3,
+      assignee: 'Jonas Prado',
+      labels: [],
+      xp: 30,
+      tasks: [],
+    };
+
+    const allowed = service.createStory(baseDraft);
+    expect(allowed).not.toBeNull();
+
+    const blocked = service.createStory({
+      ...baseDraft,
+      title: 'Overload de deploy cooperativo',
+      assignee: 'Letícia Duarte',
+    });
+    expect(blocked).toBeNull();
   });
 });

--- a/src/app/features/board/state/board-state.service.ts
+++ b/src/app/features/board/state/board-state.service.ts
@@ -3,9 +3,12 @@ import type {
   BoardCardViewModel,
   BoardColumnViewModel,
   BoardStatus,
+  BoardStatusWithCapacity,
+  CreateStoryPayload,
   Feature,
   Mission,
   Story,
+  StoryTask,
   TeamProgressSummary,
 } from './board.models';
 import { BoardConfigState } from './board-config.state';
@@ -72,8 +75,33 @@ export class BoardState {
       assignee: 'Aline Santos',
       labels: ['Analytics', 'Observability'],
       xp: 85,
-      completedChecklistItems: 3,
-      totalChecklistItems: 5,
+      tasks: [
+        {
+          id: 'task-flow-analytics-research',
+          title: 'Mapear eventos de ciclo com o time de dados',
+          isDone: true,
+        },
+        {
+          id: 'task-flow-analytics-dashboard',
+          title: 'Prototipar painéis de lead e cycle time',
+          isDone: true,
+        },
+        {
+          id: 'task-flow-analytics-api',
+          title: 'Instrumentar coleta de métricas no backend',
+          isDone: true,
+        },
+        {
+          id: 'task-flow-analytics-narrative',
+          title: 'Criar narrativa visual para squads acompanharem progresso',
+          isDone: false,
+        },
+        {
+          id: 'task-flow-analytics-review',
+          title: 'Validar indicadores com chapter de produto',
+          isDone: false,
+        },
+      ],
       dueDate: new Date().toISOString(),
     },
     {
@@ -86,8 +114,38 @@ export class BoardState {
       assignee: 'Diego Martins',
       labels: ['Gamificação', 'UI'],
       xp: 110,
-      completedChecklistItems: 1,
-      totalChecklistItems: 6,
+      tasks: [
+        {
+          id: 'task-avatars-style',
+          title: 'Definir estilo base dos avatares cooperativos',
+          isDone: true,
+        },
+        {
+          id: 'task-avatars-sync',
+          title: 'Arquitetar sincronização em tempo real',
+          isDone: false,
+        },
+        {
+          id: 'task-avatars-store',
+          title: 'Persistir acessórios desbloqueados da guilda',
+          isDone: false,
+        },
+        {
+          id: 'task-avatars-accessibility',
+          title: 'Garantir contraste e acessibilidade nos temas',
+          isDone: false,
+        },
+        {
+          id: 'task-avatars-feedback',
+          title: 'Prototipar animações de reação do squad',
+          isDone: false,
+        },
+        {
+          id: 'task-avatars-tests',
+          title: 'Planejar testes multijogador no playtest interno',
+          isDone: false,
+        },
+      ],
       dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 3).toISOString(),
     },
     {
@@ -100,8 +158,28 @@ export class BoardState {
       assignee: 'Helena Pires',
       labels: ['Backend', 'Gamificação'],
       xp: 60,
-      completedChecklistItems: 4,
-      totalChecklistItems: 4,
+      tasks: [
+        {
+          id: 'task-mission-engine-schema',
+          title: 'Modelar esquema de missões semanais',
+          isDone: true,
+        },
+        {
+          id: 'task-mission-engine-cron',
+          title: 'Implementar rotinas de agendamento de missões',
+          isDone: true,
+        },
+        {
+          id: 'task-mission-engine-rules',
+          title: 'Configurar regras de recompensa colaborativa',
+          isDone: true,
+        },
+        {
+          id: 'task-mission-engine-tests',
+          title: 'Cobrir fluxo com testes automatizados',
+          isDone: true,
+        },
+      ],
     },
     {
       id: 'story-cfd',
@@ -113,8 +191,38 @@ export class BoardState {
       assignee: 'Iuri Paiva',
       labels: ['Analytics', 'Data Viz'],
       xp: 95,
-      completedChecklistItems: 5,
-      totalChecklistItems: 6,
+      tasks: [
+        {
+          id: 'task-cfd-data',
+          title: 'Consolidar dados históricos de fluxo',
+          isDone: true,
+        },
+        {
+          id: 'task-cfd-ux',
+          title: 'Prototipar interações do gráfico cumulativo',
+          isDone: true,
+        },
+        {
+          id: 'task-cfd-performance',
+          title: 'Otimizar consultas para carregamento dinâmico',
+          isDone: true,
+        },
+        {
+          id: 'task-cfd-tooltips',
+          title: 'Implementar tooltips narrativos por etapa',
+          isDone: true,
+        },
+        {
+          id: 'task-cfd-story',
+          title: 'Conectar progresso com storytelling de guilda',
+          isDone: true,
+        },
+        {
+          id: 'task-cfd-review',
+          title: 'Validar insights com PM e analytics',
+          isDone: false,
+        },
+      ],
     },
     {
       id: 'story-team-buffs',
@@ -126,8 +234,33 @@ export class BoardState {
       assignee: 'Clara Sato',
       labels: ['Pesquisa', 'UX'],
       xp: 70,
-      completedChecklistItems: 0,
-      totalChecklistItems: 5,
+      tasks: [
+        {
+          id: 'task-team-buffs-interviews',
+          title: 'Entrevistar squads sobre rituais energizantes',
+          isDone: false,
+        },
+        {
+          id: 'task-team-buffs-catalog',
+          title: 'Catalogar buffs colaborativos possíveis',
+          isDone: false,
+        },
+        {
+          id: 'task-team-buffs-scoring',
+          title: 'Definir critérios de pontuação por buff',
+          isDone: false,
+        },
+        {
+          id: 'task-team-buffs-prototype',
+          title: 'Prototipar painel de buffs para squads',
+          isDone: false,
+        },
+        {
+          id: 'task-team-buffs-validation',
+          title: 'Rodar sessão de validação com chapter agile',
+          isDone: false,
+        },
+      ],
     },
     {
       id: 'story-onboarding',
@@ -139,10 +272,37 @@ export class BoardState {
       assignee: 'Rafael Lima',
       labels: ['Growth'],
       xp: 40,
-      completedChecklistItems: 5,
-      totalChecklistItems: 5,
+      tasks: [
+        {
+          id: 'task-onboarding-journey',
+          title: 'Mapear jornada de onboarding gamificada',
+          isDone: true,
+        },
+        {
+          id: 'task-onboarding-copy',
+          title: 'Redigir narrativa de boas-vindas',
+          isDone: true,
+        },
+        {
+          id: 'task-onboarding-assets',
+          title: 'Criar assets visuais para recompensas iniciais',
+          isDone: true,
+        },
+        {
+          id: 'task-onboarding-instrumentation',
+          title: 'Instrumentar métricas de adesão',
+          isDone: true,
+        },
+        {
+          id: 'task-onboarding-playtest',
+          title: 'Executar playtest com novos membros da guilda',
+          isDone: true,
+        },
+      ],
     },
   ]);
+
+  readonly features = this._features.asReadonly();
 
   readonly columns = computed<readonly BoardColumnViewModel[]>(() => {
     const activeStatuses = [...this.boardConfig.statuses()].filter((status) => status.isActive);
@@ -160,6 +320,18 @@ export class BoardState {
         wipLimit,
         isWipLimitBreached: wipLimit !== undefined && wipCount > wipLimit,
       } satisfies BoardColumnViewModel;
+    });
+  });
+
+  readonly statusOptions = computed<readonly BoardStatusWithCapacity[]>(() => {
+    const activeStatuses = [...this.boardConfig.statuses()].filter((status) => status.isActive);
+    activeStatuses.sort((a, b) => a.order - b.order);
+
+    return activeStatuses.map((status) => {
+      const wipCount = this._stories().filter((story) => story.statusId === status.id).length;
+      const wipLimit = status.wipLimit;
+      const isAtLimit = wipLimit !== undefined && wipCount >= wipLimit;
+      return { status, wipCount, wipLimit, isAtLimit } satisfies BoardStatusWithCapacity;
     });
   });
 
@@ -182,6 +354,57 @@ export class BoardState {
       missions: this._missions(),
     } satisfies TeamProgressSummary;
   });
+
+  createStory(draft: CreateStoryPayload): Story | null {
+    const statusesById = this.getStatusesById();
+    const nextStatus = statusesById.get(draft.statusId);
+    const title = draft.title.trim();
+    const assignee = draft.assignee.trim();
+
+    if (!nextStatus || !nextStatus.isActive || title.length === 0 || assignee.length === 0) {
+      return null;
+    }
+
+    if (!this.hasCapacityForStatus(nextStatus)) {
+      return null;
+    }
+
+    const featureExists = this._features().some((feature) => feature.id === draft.featureId);
+    if (!featureExists) {
+      return null;
+    }
+
+    const labels = draft.labels.map((label) => label.trim()).filter((label) => label.length > 0);
+    const tasks = draft.tasks
+      .map((task) => ({
+        title: task.title.trim(),
+        isDone: task.isDone,
+      }))
+      .filter((task) => task.title.length > 0)
+      .map((task) => ({
+        id: this.createId('task'),
+        title: task.title,
+        isDone: task.isDone,
+      }) satisfies StoryTask);
+
+    const newStory: Story = {
+      id: this.createId('story'),
+      featureId: draft.featureId,
+      title,
+      statusId: nextStatus.id,
+      priority: draft.priority,
+      estimate: draft.estimate,
+      assignee,
+      labels,
+      xp: draft.xp,
+      tasks,
+      dueDate: draft.dueDate && draft.dueDate.length > 0 ? draft.dueDate : undefined,
+    } satisfies Story;
+
+    this._stories.update((stories) => [newStory, ...stories]);
+
+    return newStory;
+  }
 
   moveStory(storyId: string, nextStatusId: string): boolean {
     if (!this.isMoveAllowed(storyId, nextStatusId)) {
@@ -213,9 +436,7 @@ export class BoardState {
       return false;
     }
 
-    const allowedCount = nextStatus.wipLimit ?? Number.POSITIVE_INFINITY;
-    const nextCount = this._stories().filter((item) => item.statusId === nextStatusId).length;
-    if (nextCount >= allowedCount) {
+    if (!this.hasCapacityForStatus(nextStatus)) {
       return false;
     }
 
@@ -226,8 +447,28 @@ export class BoardState {
     return new Map(this.boardConfig.statuses().map((status) => [status.id, status] as const));
   }
 
+  private hasCapacityForStatus(status: BoardStatus): boolean {
+    const allowedCount = status.wipLimit ?? Number.POSITIVE_INFINITY;
+    const nextCount = this._stories().filter((item) => item.statusId === status.id).length;
+    return nextCount < allowedCount;
+  }
+
+  private createId(prefix: string): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return `${prefix}-${crypto.randomUUID()}`;
+    }
+
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+  }
+
   private toCardViewModel(story: Story): BoardCardViewModel {
     const feature = this._features().find((item) => item.id === story.featureId);
+    const totalChecklistItems = story.tasks.length;
+    const completedChecklistItems = story.tasks.filter((task) => task.isDone).length;
+    const checklistProgressLabel =
+      totalChecklistItems === 0
+        ? 'Sem checklist'
+        : `${completedChecklistItems}/${totalChecklistItems} checklist`;
     return {
       id: story.id,
       statusId: story.statusId,
@@ -240,11 +481,9 @@ export class BoardState {
       labels: story.labels,
       estimateLabel: `${story.estimate} pts`,
       xp: story.xp,
-      checklistProgressLabel: `${story.completedChecklistItems}/${story.totalChecklistItems} checklist`,
+      checklistProgressLabel,
       completionPercent:
-        story.totalChecklistItems === 0
-          ? 0
-          : Math.round((story.completedChecklistItems / story.totalChecklistItems) * 100),
+        totalChecklistItems === 0 ? 0 : Math.round((completedChecklistItems / totalChecklistItems) * 100),
       missionTagline: feature?.mission ?? 'Missão surpresa para a guilda.',
       dueLabel: story.dueDate ? this.formatDueDate(story.dueDate) : undefined,
     } satisfies BoardCardViewModel;

--- a/src/app/features/board/state/board.models.ts
+++ b/src/app/features/board/state/board.models.ts
@@ -27,6 +27,30 @@ export interface Mission {
 
 export type Priority = 'low' | 'medium' | 'high' | 'critical';
 
+export interface StoryTask {
+  readonly id: string;
+  readonly title: string;
+  readonly isDone: boolean;
+}
+
+export interface StoryTaskDraft {
+  readonly title: string;
+  readonly isDone: boolean;
+}
+
+export interface CreateStoryPayload {
+  readonly title: string;
+  readonly featureId: string;
+  readonly statusId: string;
+  readonly priority: Priority;
+  readonly estimate: number;
+  readonly assignee: string;
+  readonly labels: readonly string[];
+  readonly xp: number;
+  readonly dueDate?: string;
+  readonly tasks: readonly StoryTaskDraft[];
+}
+
 export interface Story {
   readonly id: string;
   readonly featureId: string;
@@ -37,8 +61,7 @@ export interface Story {
   readonly assignee: string;
   readonly labels: readonly string[];
   readonly xp: number;
-  readonly completedChecklistItems: number;
-  readonly totalChecklistItems: number;
+  readonly tasks: readonly StoryTask[];
   readonly dueDate?: string;
 }
 
@@ -75,6 +98,13 @@ export interface BoardColumnViewModel {
   readonly wipCount: number;
   readonly wipLimit?: number;
   readonly isWipLimitBreached: boolean;
+}
+
+export interface BoardStatusWithCapacity {
+  readonly status: BoardStatus;
+  readonly wipCount: number;
+  readonly wipLimit?: number;
+  readonly isAtLimit: boolean;
 }
 
 export interface TeamProgressSummary {


### PR DESCRIPTION
## Summary
- add a "Nova história" CTA and standalone modal so squads can registrar novas histórias diretamente do quadro
- expand the board state to armazenar tarefas tipadas, gerar progresso de checklist e validar limites de WIP ao criar histórias
- cobrir o novo fluxo com testes e documentar o modal de criação no README da feature

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcf6c42d483339d01da1ab01a2d05