### PR TITLE
Center create story modal in viewport

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -236,7 +236,6 @@
 .shell-main {
   padding: clamp(1rem, 2.5vw, 2rem);
   position: relative;
-  z-index: 0;
   display: flex;
   flex-direction: column;
   min-height: 0;

--- a/src/app/features/board/components/create-story-modal/create-story-modal.component.scss
+++ b/src/app/features/board/components/create-story-modal/create-story-modal.component.scss
@@ -1,8 +1,12 @@
 .create-story-modal {
+  --create-story-modal-padding: clamp(1rem, 4vw, 2.5rem);
+
   position: fixed;
   inset: 0;
   display: grid;
-  place-items: center;
+  align-items: center;
+  justify-items: center;
+  padding: var(--create-story-modal-padding);
   z-index: 1000;
 }
 
@@ -15,8 +19,8 @@
 
 .create-story-modal__panel {
   position: relative;
-  width: min(720px, calc(100vw - 2rem));
-  max-height: calc(100vh - 3rem);
+  width: min(720px, 100%);
+  max-height: calc(100vh - 2 * var(--create-story-modal-padding));
   overflow: auto;
   border-radius: 1.5rem;
   border: 1px solid rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
## Summary
- ensure the create story modal overlay includes responsive padding and centers its panel regardless of viewport size
- size the modal panel using the shared padding value so it stays fully visible while remaining centered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd3c56fb48333bcecfb715cc7fc74