### PR TITLE
Add feature explorer screens for features and stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Hero Kanban transforma o fluxo de trabalho tradicional em uma jornada cooperativ
 
 - Projeto Angular 19 com **standalone components** e **signals** para estado local (`BoardState`).
 - Organização por features em `src/app/features`, seguindo boas práticas do `AGENT.md`.
+- **Feature Explorer** dedicado para navegar entre features e histórias. Reaproveita o `BoardState` para manter uma fonte única de dados.
 - UI construída com componentes puros (`BoardPage`, `BoardColumn`, `BoardCard`) focados em acessibilidade e tipagem forte (`board.models.ts`).
 - Fluxo gamificado demonstrado por dados mockados: níveis do time, progresso de XP e missões com feedback visual.
 
@@ -31,7 +32,7 @@ O servidor sobe em `http://localhost:4200/`. O layout é responsivo e suporta na
 npm test -- --watch=false
 ```
 
-Os testes validam a criação do shell principal e regras de transição/WIP do serviço `BoardState`.
+Os testes validam a criação do shell principal, regras de transição/WIP do serviço `BoardState` e os view models agregados do `FeatureExplorerState`.
 
 ## Próximos passos sugeridos
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -54,6 +54,11 @@
             >Quadro</a>
         </li>
         <li>
+          <a routerLink="/features" routerLinkActive="is-active" (click)="closeMenu()">
+            Features &amp; histórias
+          </a>
+        </li>
+        <li>
           <a routerLink="/perfil" routerLinkActive="is-active" (click)="closeMenu()">Perfil</a>
         </li>
         <li>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,6 +19,13 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'features',
+    loadChildren: () =>
+      import('./features/feature-explorer/feature-explorer.routes').then(
+        (m) => m.FEATURE_EXPLORER_ROUTES,
+      ),
+  },
+  {
     path: '**',
     redirectTo: '',
   },

--- a/src/app/features/board/state/board-state.service.ts
+++ b/src/app/features/board/state/board-state.service.ts
@@ -303,6 +303,7 @@ export class BoardState {
   ]);
 
   readonly features = this._features.asReadonly();
+  readonly stories = this._stories.asReadonly();
 
   readonly columns = computed<readonly BoardColumnViewModel[]>(() => {
     const activeStatuses = [...this.boardConfig.statuses()].filter((status) => status.isActive);

--- a/src/app/features/feature-explorer/README.md
+++ b/src/app/features/feature-explorer/README.md
@@ -1,0 +1,31 @@
+# Feature Explorer
+
+## Objetivo
+Oferecer uma visão dedicada das features estratégicas e das histórias que as sustentam, permitindo que a guilda compreenda rápida
+mente o contexto, o progresso e o impacto de cada missão antes de mergulhar no quadro Kanban.
+
+## Decisões técnicas
+- **Reaproveito do `BoardState`** para manter fonte única de verdade para features e histórias, evitando divergência de dados.
+- **ViewModels específicos** (`FeatureOverviewCardViewModel`, `FeatureDetailViewModel`) preparados em `FeatureExplorerState` ga
+rantem que o template receba apenas o necessário para renderizar cartões responsivos.
+- **Signals + `computed`** mantêm a UI sincronizada com updates do `BoardState`, permitindo futuras integrações com API sem alt
+erar os componentes.
+- **Tipagem forte** herdada dos modelos do quadro (`Feature`, `Story`) para assegurar consistência entre páginas.
+
+## Uso
+```ts
+import { FEATURE_EXPLORER_ROUTES } from '@features/feature-explorer/feature-explorer.routes';
+```
+As rotas lazy-loaded expõem duas páginas standalone:
+- `FeatureCatalogPage`: catálogo com cards de features e métricas principais.
+- `FeatureDetailPage`: detalhes da feature com cards das histórias vinculadas.
+
+## Dependências externas
+Nenhuma dependência adicional além do Angular padrão. Reutiliza tokens de cor globais definidos em `styles.scss` para manter a e
+stética neon do app.
+
+## Checklist de manutenção
+- [ ] Atualizar mocks em `BoardState` quando integrações reais entregarem dados de features/histórias.
+- [ ] Avaliar paginação/agrupamento se o número de histórias crescer.
+- [ ] Medir contraste dos cartões em temas alternativos.
+- [ ] Adicionar testes de integração ao navegar entre catálogo e detalhe quando o roteamento ganhar mais regras.

--- a/src/app/features/feature-explorer/feature-explorer.routes.ts
+++ b/src/app/features/feature-explorer/feature-explorer.routes.ts
@@ -1,0 +1,14 @@
+import { Routes } from '@angular/router';
+import { FeatureCatalogPage } from './pages/feature-catalog.page';
+import { FeatureDetailPage } from './pages/feature-detail.page';
+
+export const FEATURE_EXPLORER_ROUTES: Routes = [
+  {
+    path: '',
+    component: FeatureCatalogPage,
+  },
+  {
+    path: ':featureId',
+    component: FeatureDetailPage,
+  },
+];

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.html
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.html
@@ -1,0 +1,57 @@
+<section class="catalog" aria-labelledby="feature-catalog-title">
+  <header class="catalog__header">
+    <h1 id="feature-catalog-title">Explorar features e histórias</h1>
+    <p>
+      Conheça as missões épicas em andamento. Cada feature reúne histórias que impulsionam a jornada da guilda.
+    </p>
+  </header>
+
+  <ng-container *ngIf="featureCards().length > 0; else emptyState">
+    <div class="catalog__grid" role="list">
+      <article
+        *ngFor="let feature of featureCards(); trackBy: trackById"
+        role="listitem"
+        class="feature-card"
+      >
+        <header class="feature-card__header">
+          <h2>{{ feature.title }}</h2>
+          <p class="feature-card__theme">{{ feature.theme }}</p>
+        </header>
+
+        <p class="feature-card__mission">{{ feature.mission }}</p>
+
+        <dl class="feature-card__metrics">
+          <div>
+            <dt>Progresso</dt>
+            <dd>{{ feature.progressPercent }}% concluída</dd>
+          </div>
+          <div>
+            <dt>Histórias</dt>
+            <dd>{{ feature.storyCount }} em andamento</dd>
+          </div>
+          <div>
+            <dt>Recompensa</dt>
+            <dd>{{ feature.xpRewardLabel }}</dd>
+          </div>
+        </dl>
+
+        <div
+          class="feature-card__progress"
+          role="progressbar"
+          [attr.aria-valuenow]="feature.progressPercent"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          [attr.aria-label]="'Progresso da feature ' + feature.title"
+        >
+          <span class="feature-card__progress-bar" [style.width.%]="feature.progressPercent"></span>
+        </div>
+
+        <a [routerLink]="['/features', feature.id]" class="feature-card__link">Ver detalhes da feature</a>
+      </article>
+    </div>
+  </ng-container>
+</section>
+
+<ng-template #emptyState>
+  <p class="catalog__empty">Nenhuma feature encontrada no momento.</p>
+</ng-template>

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.scss
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.scss
@@ -1,0 +1,145 @@
+.catalog {
+  display: grid;
+  gap: 2rem;
+  color: var(--hk-text-secondary);
+}
+
+.catalog__header {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 60ch;
+}
+
+.catalog__header > h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.4rem);
+  color: var(--hk-text-primary);
+}
+
+.catalog__header > p {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.catalog__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(18.5rem, 1fr));
+}
+
+.feature-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: var(--hk-surface-elevated);
+  border: 1px solid var(--hk-border);
+  box-shadow: 0 1.2rem 2.5rem rgba(7, 8, 20, 0.35);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.feature-card:hover,
+.feature-card:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(124, 92, 255, 0.55);
+  box-shadow: 0 1.75rem 3.5rem rgba(12, 10, 40, 0.55);
+}
+
+.feature-card__header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.feature-card__header > h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--hk-text-primary);
+}
+
+.feature-card__theme {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--hk-text-muted);
+}
+
+.feature-card__mission {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--hk-text-secondary);
+}
+
+.feature-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.feature-card__metrics div {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.65rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.feature-card__metrics dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--hk-text-muted);
+}
+
+.feature-card__metrics dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--hk-text-primary);
+  font-weight: 600;
+}
+
+.feature-card__progress {
+  position: relative;
+  width: 100%;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.feature-card__progress-bar {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7c5cff 0%, #6366f1 50%, #22d3ee 100%);
+}
+
+.feature-card__link {
+  justify-self: flex-start;
+  padding: 0.6rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(124, 92, 255, 0.18);
+  border: 1px solid rgba(124, 92, 255, 0.35);
+  color: var(--hk-text-primary);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.feature-card__link:hover,
+.feature-card__link:focus-visible {
+  background: rgba(124, 92, 255, 0.35);
+  border-color: rgba(124, 92, 255, 0.55);
+}
+
+.catalog__empty {
+  margin: 2rem 0 0;
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  max-width: 38ch;
+}

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.ts
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import type { FeatureOverviewCardViewModel } from '../state/feature-explorer.models';
+import { FeatureExplorerState } from '../state/feature-explorer.state';
+
+@Component({
+  selector: 'hk-feature-catalog-page',
+  standalone: true,
+  templateUrl: './feature-catalog.page.html',
+  styleUrls: ['./feature-catalog.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIf, NgFor, RouterLink],
+})
+export class FeatureCatalogPage {
+  private readonly featureExplorerState = inject(FeatureExplorerState);
+
+  protected readonly featureCards = this.featureExplorerState.featureCards;
+
+  protected trackById(_: number, card: FeatureOverviewCardViewModel): string {
+    return card.id;
+  }
+}

--- a/src/app/features/feature-explorer/pages/feature-detail.page.html
+++ b/src/app/features/feature-explorer/pages/feature-detail.page.html
@@ -1,0 +1,86 @@
+<ng-container *ngIf="feature() as feature; else notFound">
+  <section class="feature-detail" aria-labelledby="feature-detail-title">
+    <nav class="feature-detail__breadcrumb" aria-label="Navegação secundária">
+      <a routerLink="/features">← Voltar para catálogo</a>
+    </nav>
+
+    <header class="feature-detail__header">
+      <h1 id="feature-detail-title">{{ feature.title }}</h1>
+      <p class="feature-detail__theme">{{ feature.theme }}</p>
+      <p class="feature-detail__mission">{{ feature.mission }}</p>
+
+      <dl class="feature-detail__metrics">
+        <div>
+          <dt>Progresso</dt>
+          <dd>
+            <span class="feature-detail__progress" role="presentation">
+              <span class="feature-detail__progress-bar" [style.width.%]="feature.progressPercent"></span>
+            </span>
+            <span class="feature-detail__metric-value">{{ feature.progressPercent }}% concluída</span>
+          </dd>
+        </div>
+        <div>
+          <dt>Recompensa</dt>
+          <dd class="feature-detail__metric-value">{{ feature.xpRewardLabel }}</dd>
+        </div>
+        <div>
+          <dt>Histórias</dt>
+          <dd class="feature-detail__metric-value">{{ feature.storyCount }}</dd>
+        </div>
+      </dl>
+    </header>
+
+    <section class="story-section" aria-labelledby="feature-stories-title">
+      <div class="story-section__header">
+        <h2 id="feature-stories-title">Histórias vinculadas</h2>
+        <p>Cards com status, prioridade e responsável de cada missão.</p>
+      </div>
+
+      <ng-container *ngIf="feature.stories.length > 0; else noStories">
+        <div class="story-grid" role="list">
+          <article
+            *ngFor="let story of feature.stories; trackBy: trackStory"
+            role="listitem"
+            class="story-card"
+          >
+            <header class="story-card__header">
+              <span class="story-card__status" [style.backgroundColor]="story.statusColor">{{ story.statusLabel }}</span>
+              <span class="story-card__priority" [style.color]="story.priorityColor">{{ story.priorityLabel }}</span>
+            </header>
+
+            <h3 class="story-card__title">{{ story.title }}</h3>
+
+            <dl class="story-card__meta">
+              <div>
+                <dt>Responsável</dt>
+                <dd>{{ story.assignee }}</dd>
+              </div>
+              <div>
+                <dt>XP</dt>
+                <dd>{{ story.xpLabel }}</dd>
+              </div>
+              <div>
+                <dt>Estimativa</dt>
+                <dd>{{ story.estimateLabel }}</dd>
+              </div>
+            </dl>
+
+            <p class="story-card__checklist">{{ story.checklistProgressLabel }}</p>
+            <p class="story-card__due" *ngIf="story.dueLabel as dueLabel">Entrega prevista: {{ dueLabel }}</p>
+          </article>
+        </div>
+      </ng-container>
+    </section>
+  </section>
+</ng-container>
+
+<ng-template #noStories>
+  <p class="story-section__empty">Nenhuma história vinculada a esta feature ainda.</p>
+</ng-template>
+
+<ng-template #notFound>
+  <section class="feature-detail feature-detail--empty">
+    <p>Não encontramos a feature solicitada. Volte para o catálogo para explorar outras missões.</p>
+    <a routerLink="/features" class="feature-detail__link">Abrir catálogo</a>
+  </section>
+</ng-template>

--- a/src/app/features/feature-explorer/pages/feature-detail.page.scss
+++ b/src/app/features/feature-explorer/pages/feature-detail.page.scss
@@ -1,0 +1,263 @@
+.feature-detail {
+  display: grid;
+  gap: 2.5rem;
+  padding: clamp(1rem, 3vw, 2rem);
+  background: rgba(17, 19, 36, 0.72);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 2rem 3.5rem rgba(8, 9, 22, 0.4);
+  color: var(--hk-text-secondary);
+}
+
+.feature-detail__breadcrumb {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.feature-detail__breadcrumb > a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-decoration: none;
+  color: var(--hk-text-primary);
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.feature-detail__breadcrumb > a:hover,
+.feature-detail__breadcrumb > a:focus-visible {
+  background: rgba(124, 92, 255, 0.35);
+  border-color: rgba(124, 92, 255, 0.55);
+}
+
+.feature-detail__header {
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-detail__header > h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  color: var(--hk-text-primary);
+}
+
+.feature-detail__theme {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--hk-text-muted);
+}
+
+.feature-detail__mission {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.feature-detail__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.feature-detail__metrics div {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.feature-detail__metrics dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hk-text-muted);
+}
+
+.feature-detail__metrics dd {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.feature-detail__metric-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--hk-text-primary);
+}
+
+.feature-detail__progress {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.feature-detail__progress-bar {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #22d3ee 0%, #6366f1 50%, #a855f7 100%);
+}
+
+.story-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.story-section__header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.story-section__header > h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.85rem);
+  color: var(--hk-text-primary);
+}
+
+.story-section__header > p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.story-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+}
+
+.story-card {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: rgba(20, 22, 42, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 1.2rem 2.6rem rgba(7, 8, 20, 0.45);
+}
+
+.story-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.story-card__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #0f0c29;
+}
+
+.story-card__priority {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.story-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--hk-text-primary);
+}
+
+.story-card__meta {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  grid-template-columns: repeat(auto-fit, minmax(8.5rem, 1fr));
+}
+
+.story-card__meta div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.story-card__meta dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hk-text-muted);
+}
+
+.story-card__meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--hk-text-primary);
+}
+
+.story-card__checklist {
+  margin: 0;
+  color: var(--hk-text-secondary);
+}
+
+.story-card__due {
+  margin: 0;
+  color: var(--hk-warning);
+  font-weight: 600;
+}
+
+.story-section__empty {
+  margin: 0;
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px dashed rgba(255, 255, 255, 0.16);
+  max-width: 32ch;
+}
+
+.feature-detail--empty {
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.feature-detail__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.2rem;
+  border-radius: 0.9rem;
+  background: rgba(124, 92, 255, 0.25);
+  border: 1px solid rgba(124, 92, 255, 0.45);
+  color: var(--hk-text-primary);
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.feature-detail__link:hover,
+.feature-detail__link:focus-visible {
+  background: rgba(124, 92, 255, 0.4);
+  border-color: rgba(124, 92, 255, 0.6);
+}
+
+@media (max-width: 720px) {
+  .feature-detail {
+    padding: 1.25rem;
+  }
+
+  .story-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/features/feature-explorer/pages/feature-detail.page.ts
+++ b/src/app/features/feature-explorer/pages/feature-detail.page.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs/operators';
+import type { FeatureStoryCardViewModel } from '../state/feature-explorer.models';
+import { FeatureExplorerState } from '../state/feature-explorer.state';
+
+@Component({
+  selector: 'hk-feature-detail-page',
+  standalone: true,
+  templateUrl: './feature-detail.page.html',
+  styleUrls: ['./feature-detail.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIf, NgFor, RouterLink],
+})
+export class FeatureDetailPage {
+  private readonly featureExplorerState = inject(FeatureExplorerState);
+  private readonly route = inject(ActivatedRoute);
+
+  private readonly featureId = toSignal(
+    this.route.paramMap.pipe(map((params) => params.get('featureId') ?? '')),
+    { initialValue: this.route.snapshot.paramMap.get('featureId') ?? '' },
+  );
+
+  protected readonly feature = computed(() => {
+    const id = this.featureId().trim();
+    if (id.length === 0) {
+      return undefined;
+    }
+
+    return this.featureExplorerState.getFeatureDetail(id);
+  });
+
+  protected trackStory(_: number, story: FeatureStoryCardViewModel): string {
+    return story.id;
+  }
+}

--- a/src/app/features/feature-explorer/state/feature-explorer.models.ts
+++ b/src/app/features/feature-explorer/state/feature-explorer.models.ts
@@ -1,0 +1,36 @@
+import type { Feature } from '@features/board/state/board.models';
+
+export interface FeatureOverviewCardViewModel {
+  readonly id: Feature['id'];
+  readonly title: string;
+  readonly theme: string;
+  readonly mission: string;
+  readonly progressPercent: number;
+  readonly storyCount: number;
+  readonly xpRewardLabel: string;
+}
+
+export interface FeatureStoryCardViewModel {
+  readonly id: string;
+  readonly title: string;
+  readonly statusLabel: string;
+  readonly statusColor: string;
+  readonly priorityLabel: string;
+  readonly priorityColor: string;
+  readonly assignee: string;
+  readonly xpLabel: string;
+  readonly estimateLabel: string;
+  readonly checklistProgressLabel: string;
+  readonly dueLabel?: string;
+}
+
+export interface FeatureDetailViewModel {
+  readonly id: Feature['id'];
+  readonly title: string;
+  readonly theme: string;
+  readonly mission: string;
+  readonly xpRewardLabel: string;
+  readonly progressPercent: number;
+  readonly storyCount: number;
+  readonly stories: readonly FeatureStoryCardViewModel[];
+}

--- a/src/app/features/feature-explorer/state/feature-explorer.state.spec.ts
+++ b/src/app/features/feature-explorer/state/feature-explorer.state.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { FeatureExplorerState } from './feature-explorer.state';
+
+describe('FeatureExplorerState', () => {
+  let state: FeatureExplorerState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    state = TestBed.inject(FeatureExplorerState);
+  });
+
+  it('should expose feature cards aggregated with story count', () => {
+    const cards = state.featureCards();
+    expect(cards.length).toBeGreaterThan(0);
+
+    const progressGraph = cards.find((card) => card.id === 'feat-progress-graph');
+    expect(progressGraph).toBeDefined();
+    expect(progressGraph?.storyCount).toBeGreaterThan(0);
+    expect(progressGraph?.xpRewardLabel).toBe('250 XP');
+  });
+
+  it('should resolve detail view models with story metadata', () => {
+    const detail = state.getFeatureDetail('feat-progress-graph');
+    expect(detail).toBeDefined();
+    expect(detail?.stories.length).toBeGreaterThan(0);
+
+    const story = detail?.stories.find((item) => item.id === 'story-flow-analytics');
+    expect(story).toBeDefined();
+    expect(story?.priorityLabel).toBe('Crítico');
+    expect(story?.xpLabel).toBe('85 XP');
+    expect(story?.checklistProgressLabel).toContain('/');
+    expect(story?.statusLabel.length).toBeGreaterThan(0);
+    expect(story?.dueLabel).toBeDefined();
+  });
+
+  it('should return undefined for unknown features', () => {
+    expect(state.getFeatureDetail('unknown-feature')).toBeUndefined();
+  });
+});

--- a/src/app/features/feature-explorer/state/feature-explorer.state.ts
+++ b/src/app/features/feature-explorer/state/feature-explorer.state.ts
@@ -1,0 +1,126 @@
+import { computed, inject, Injectable } from '@angular/core';
+import type { Feature, Priority, Story } from '@features/board/state/board.models';
+import { BoardConfigState } from '@features/board/state/board-config.state';
+import { BoardState } from '@features/board/state/board-state.service';
+import type {
+  FeatureDetailViewModel,
+  FeatureOverviewCardViewModel,
+  FeatureStoryCardViewModel,
+} from './feature-explorer.models';
+
+const PRIORITY_METADATA: Record<Priority, { readonly label: string; readonly color: string }> = {
+  low: { label: 'Baixo', color: '#4ade80' },
+  medium: { label: 'Médio', color: '#facc15' },
+  high: { label: 'Alto', color: '#fb7185' },
+  critical: { label: 'Crítico', color: '#f97316' },
+} as const;
+
+@Injectable({ providedIn: 'root' })
+export class FeatureExplorerState {
+  private readonly boardState = inject(BoardState);
+  private readonly boardConfig = inject(BoardConfigState);
+
+  readonly featureCards = computed<readonly FeatureOverviewCardViewModel[]>(() => {
+    const features = this.boardState.features();
+    const stories = this.boardState.stories();
+    const storyCountByFeature = stories.reduce(
+      (accumulator, story) => accumulator.set(story.featureId, (accumulator.get(story.featureId) ?? 0) + 1),
+      new Map<string, number>(),
+    );
+
+    return features
+      .map((feature) => this.toFeatureCard(feature, storyCountByFeature.get(feature.id) ?? 0))
+      .sort((a, b) => a.title.localeCompare(b.title, 'pt-BR'));
+  });
+
+  private readonly featureDetailsMap = computed<ReadonlyMap<string, FeatureDetailViewModel>>(() => {
+    const statuses = this.boardConfig.statuses();
+    const statusById = new Map(statuses.map((status) => [status.id, status] as const));
+    const features = this.boardState.features();
+    const stories = this.boardState.stories();
+
+    const storyCardsByFeature = new Map<string, FeatureStoryCardViewModel[]>();
+    for (const story of stories) {
+      const status = statusById.get(story.statusId);
+      const statusLabel = status?.name ?? 'Status desconhecido';
+      const statusColor = status?.color ?? '#64748b';
+      const storyCard = this.toStoryCard(story, statusLabel, statusColor);
+      const existing = storyCardsByFeature.get(story.featureId) ?? [];
+      storyCardsByFeature.set(story.featureId, [...existing, storyCard]);
+    }
+
+    return new Map(
+      features.map((feature) => {
+        const storyCards = [...(storyCardsByFeature.get(feature.id) ?? [])];
+        storyCards.sort((a, b) => a.title.localeCompare(b.title, 'pt-BR'));
+
+        return [
+          feature.id,
+          {
+            id: feature.id,
+            title: feature.title,
+            theme: feature.theme,
+            mission: feature.mission,
+            xpRewardLabel: `${feature.xpReward} XP`,
+            progressPercent: Math.round(feature.progress * 100),
+            storyCount: storyCards.length,
+            stories: storyCards,
+          } satisfies FeatureDetailViewModel,
+        ] as const;
+      }),
+    );
+  });
+
+  getFeatureDetail(featureId: string): FeatureDetailViewModel | undefined {
+    return this.featureDetailsMap().get(featureId);
+  }
+
+  private toFeatureCard(feature: Feature, storyCount: number): FeatureOverviewCardViewModel {
+    return {
+      id: feature.id,
+      title: feature.title,
+      theme: feature.theme,
+      mission: feature.mission,
+      progressPercent: Math.round(feature.progress * 100),
+      storyCount,
+      xpRewardLabel: `${feature.xpReward} XP`,
+    } satisfies FeatureOverviewCardViewModel;
+  }
+
+  private toStoryCard(
+    story: Story,
+    statusLabel: string,
+    statusColor: string,
+  ): FeatureStoryCardViewModel {
+    const priorityMetadata = PRIORITY_METADATA[story.priority];
+    const totalChecklistItems = story.tasks.length;
+    const completedChecklistItems = story.tasks.filter((task) => task.isDone).length;
+
+    const checklistProgressLabel =
+      totalChecklistItems === 0
+        ? 'Sem checklist'
+        : `${completedChecklistItems}/${totalChecklistItems} checklist`;
+
+    return {
+      id: story.id,
+      title: story.title,
+      statusLabel,
+      statusColor,
+      priorityLabel: priorityMetadata.label,
+      priorityColor: priorityMetadata.color,
+      assignee: story.assignee,
+      xpLabel: `${story.xp} XP`,
+      estimateLabel: `${story.estimate} pts`,
+      checklistProgressLabel,
+      dueLabel: story.dueDate ? this.formatDueDate(story.dueDate) : undefined,
+    } satisfies FeatureStoryCardViewModel;
+  }
+
+  private formatDueDate(dueIso: string): string {
+    const dueDate = new Date(dueIso);
+    return new Intl.DateTimeFormat('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+    }).format(dueDate);
+  }
+}


### PR DESCRIPTION
## Summary
- create a feature explorer catalog and detail flow to browse features and their stories with styled cards
- reuse the board state through a dedicated FeatureExplorerState (exposing read-only stories) and cover it with unit tests
- expose the new routes in navigation and document the feature for future maintenance

## Testing
- npm test -- --watch=false *(fails: Chrome binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd6d369bc8333a2a76bcc286dc326