### PR TITLE
feat: add sprint planning hub and filter

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,7 +32,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ],
             "scripts": []
@@ -92,7 +91,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ],
             "scripts": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@angular/compiler": "^19.0.0",
         "@angular/core": "^19.0.0",
         "@angular/forms": "^19.0.0",
-        "@angular/material": "^19.2.19",
         "@angular/platform-browser": "^19.0.0",
         "@angular/platform-browser-dynamic": "^19.0.0",
         "@angular/router": "^19.0.0",
@@ -596,23 +595,6 @@
         "@angular/common": "19.2.15",
         "@angular/core": "19.2.15",
         "@angular/platform-browser": "19.2.15",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@angular/material": {
-      "version": "19.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.2.19.tgz",
-      "integrity": "sha512-auIE6JUzTIA3LyYklh9J/T7u64crmphxUBgAa0zcOMDog6SYfwbNe9YeLQqua5ek4OUAOdK/BHHfVl5W5iaUoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/cdk": "19.2.19",
-        "@angular/common": "^19.0.0 || ^20.0.0",
-        "@angular/core": "^19.0.0 || ^20.0.0",
-        "@angular/forms": "^19.0.0 || ^20.0.0",
-        "@angular/platform-browser": "^19.0.0 || ^20.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",
     "@angular/forms": "^19.0.0",
-    "@angular/material": "^19.2.19",
     "@angular/platform-browser": "^19.0.0",
     "@angular/platform-browser-dynamic": "^19.0.0",
     "@angular/router": "^19.0.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -54,6 +54,9 @@
             >Quadro</a>
         </li>
         <li>
+          <a routerLink="/sprints" routerLinkActive="is-active" (click)="closeMenu()">Sprints</a>
+        </li>
+        <li>
           <a routerLink="/features" routerLinkActive="is-active" (click)="closeMenu()">
             Features &amp; histórias
           </a>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -26,6 +26,11 @@ export const routes: Routes = [
       ),
   },
   {
+    path: 'sprints',
+    loadChildren: () =>
+      import('./features/sprints/sprints.routes').then((m) => m.SPRINTS_ROUTES),
+  },
+  {
     path: '**',
     redirectTo: '',
   },

--- a/src/app/features/board/README.md
+++ b/src/app/features/board/README.md
@@ -10,6 +10,7 @@ Fornecer um quadro Kanban gamificado que represente a hierarquia Feature → His
 - **Componentes standalone** desacoplados (`BoardColumn`, `BoardCard`) facilitam testes e composição de UI.
 - **Drag-and-drop nativo** com HTML5 + `BoardDragState` garante movimentação entre colunas respeitando limites de WIP e workflow configurado.
 - **Transições validadas** no serviço (`moveStory`) respeitam workflow configurável e limites de WIP.
+- **Planejamento de sprint integrado**: `BoardState` expõe `sprintFilterOptions`, `setSprintFilter` e `sprintOverviews`, permitindo filtrar o quadro por sprint e reutilizar os mesmos dados no hub dedicado de sprints.
 
 ## Uso
 ```ts
@@ -24,6 +25,7 @@ Rotas lazy-loaded já expõem a `BoardPage`. Componentes podem ser reutilizados 
 - O botão **Nova história** abre o modal standalone `CreateStoryModalComponent`, reunindo dados da missão (título, feature, status, prioridade, responsável, XP e etiquetas) no mesmo visual neon futurista do quadro.
 - As tarefas inseridas no modal tornam-se `StoryTask` tipadas no `BoardState`, alimentando automaticamente o checklist exibido em cada `BoardCard`.
 - O estado valida limites de WIP antes de persistir a nova história; etapas saturadas aparecem desabilitadas no seletor do modal.
+- Histórias podem ser associadas a uma sprint (`sprintId`) e o filtro lateral do quadro consome esse vínculo para mostrar apenas as missões relevantes daquela janela de entrega.
 
 ## Checklist de manutenção
 - [ ] Atualizar mocks em `BoardState` ao integrar API real.

--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -6,7 +6,7 @@
         <p>Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.</p>
       </div>
       <button type="button" class="board__new-story" (click)="openCreateStory()">
-        <mat-icon aria-hidden="true">add_circle</mat-icon>
+        <span class="board__new-story-icon" aria-hidden="true">add_circle</span>
         Nova história
       </button>
     </div>
@@ -34,6 +34,20 @@
           <dd>{{ summary().weeklyThroughput }}</dd>
         </div>
       </dl>
+    </div>
+    <div class="board__filters" role="region" aria-label="Filtros do quadro">
+      <label class="board__filter" for="board-sprint-filter">
+        <span class="board__filter-label">Sprint</span>
+        <select
+          #sprintSelector
+          id="board-sprint-filter"
+          class="board__filter-select"
+          (change)="onSprintFilterSelected(sprintSelector.value)"
+          [value]="selectedSprintId()"
+        >
+          <option *ngFor="let option of sprintOptions()" [value]="option.id">{{ option.label }}</option>
+        </select>
+      </label>
     </div>
     <aside class="board__missions" *ngIf="summary().missions.length > 0" aria-label="Missões em destaque">
       <h2>Missões</h2>

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -73,6 +73,14 @@
   transition: transform 0.2s ease, filter 0.2s ease;
 }
 
+.board__new-story-icon {
+  font-family: 'Material Symbols Rounded';
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
 .board__new-story:hover,
 .board__new-story:focus-visible {
   transform: translateY(-1px);
@@ -83,6 +91,48 @@
   display: grid;
   gap: 0.75rem;
   align-content: start;
+}
+
+.board__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.board__filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: min(280px, 100%);
+  color: var(--hk-text-secondary);
+  font-size: 0.85rem;
+}
+
+.board__filter-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.board__filter-select {
+  appearance: none;
+  padding: 0.6rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--hk-text-primary);
+  font-size: 0.95rem;
+  line-height: 1.2;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.board__filter-select:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+  border-color: rgba(99, 102, 241, 0.65);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);
 }
 
 .board__level {

--- a/src/app/features/board/pages/board.page.ts
+++ b/src/app/features/board/pages/board.page.ts
@@ -4,7 +4,6 @@ import type { BoardColumnViewModel, CreateStoryPayload } from '../state/board.mo
 import { BoardState } from '../state/board-state.service';
 import { BoardColumnComponent } from '../components/board-column/board-column.component';
 import { CreateStoryModalComponent } from '../components/create-story-modal/create-story-modal.component';
-import {MatIconModule} from '@angular/material/icon';
 
 
 @Component({
@@ -13,7 +12,7 @@ import {MatIconModule} from '@angular/material/icon';
   templateUrl: './board.page.html',
   styleUrls: ['./board.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, NgIf, DecimalPipe, BoardColumnComponent, CreateStoryModalComponent, MatIconModule],
+  imports: [NgFor, NgIf, DecimalPipe, BoardColumnComponent, CreateStoryModalComponent],
 })
 export class BoardPageComponent {
   private readonly boardState = inject(BoardState);
@@ -22,6 +21,8 @@ export class BoardPageComponent {
   protected readonly summary = this.boardState.summary;
   protected readonly features = this.boardState.features;
   protected readonly statusOptions = this.boardState.statusOptions;
+  protected readonly sprintOptions = this.boardState.sprintFilterOptions;
+  protected readonly selectedSprintId = this.boardState.selectedSprintId;
   protected readonly isCreatingStory = signal(false);
 
   protected trackColumn(_: number, column: BoardColumnViewModel): string {
@@ -41,5 +42,9 @@ export class BoardPageComponent {
     if (created) {
       this.isCreatingStory.set(false);
     }
+  }
+
+  protected onSprintFilterSelected(sprintId: string): void {
+    this.boardState.setSprintFilter(sprintId);
   }
 }

--- a/src/app/features/board/state/board-state.service.spec.ts
+++ b/src/app/features/board/state/board-state.service.spec.ts
@@ -88,4 +88,37 @@ describe('BoardState', () => {
     });
     expect(blocked).toBeNull();
   });
+
+  it('should filter visible cards by selected sprint', () => {
+    const allColumns = service.columns();
+    const allVisibleIds = allColumns.flatMap((column) => column.cards.map((card) => card.id));
+    expect(allVisibleIds).toContain('story-flow-analytics');
+    expect(allVisibleIds).toContain('story-mission-engine');
+
+    service.setSprintFilter('sprint-aether');
+    const filteredIds = service
+      .columns()
+      .flatMap((column) => column.cards.map((card) => card.id));
+
+    expect(filteredIds).toContain('story-mission-engine');
+    expect(filteredIds).toContain('story-team-buffs');
+    expect(filteredIds).not.toContain('story-flow-analytics');
+  });
+
+  it('should summarise sprints with their stories and totals', () => {
+    const overviews = service.sprintOverviews();
+    const nebula = overviews.find((item) => item.sprint.id === 'sprint-nebula');
+    expect(nebula).toBeDefined();
+    expect(nebula?.plannedStories).toBeGreaterThan(0);
+    expect(nebula?.stories.some((story) => story.id === 'story-flow-analytics')).toBeTrue();
+    expect(nebula?.totalPoints).toBeGreaterThan(0);
+  });
+
+  it('should reset sprint filter when an unknown sprint is provided', () => {
+    service.setSprintFilter('sprint-aether');
+    expect(service.selectedSprintId()).toBe('sprint-aether');
+
+    service.setSprintFilter('unknown-sprint');
+    expect(service.selectedSprintId()).toBe('all-sprints');
+  });
 });

--- a/src/app/features/board/state/board.models.ts
+++ b/src/app/features/board/state/board.models.ts
@@ -25,6 +25,20 @@ export interface Mission {
   readonly progress: number;
 }
 
+export interface Sprint {
+  readonly id: string;
+  readonly name: string;
+  readonly goal: string;
+  readonly focus: string;
+  readonly startDateIso: string;
+  readonly endDateIso: string;
+}
+
+export interface SprintFilterOption {
+  readonly id: string;
+  readonly label: string;
+}
+
 export type Priority = 'low' | 'medium' | 'high' | 'critical';
 
 export interface StoryTask {
@@ -49,6 +63,7 @@ export interface CreateStoryPayload {
   readonly xp: number;
   readonly dueDate?: string;
   readonly tasks: readonly StoryTaskDraft[];
+  readonly sprintId?: string | null;
 }
 
 export interface Story {
@@ -63,6 +78,7 @@ export interface Story {
   readonly xp: number;
   readonly tasks: readonly StoryTask[];
   readonly dueDate?: string;
+  readonly sprintId?: string;
 }
 
 export interface Feature {
@@ -116,4 +132,29 @@ export interface TeamProgressSummary {
   readonly activeFeatures: number;
   readonly weeklyThroughput: number;
   readonly missions: readonly Mission[];
+}
+
+export interface SprintStoryTaskViewModel {
+  readonly id: string;
+  readonly title: string;
+  readonly isDone: boolean;
+}
+
+export interface SprintStoryViewModel {
+  readonly id: string;
+  readonly title: string;
+  readonly estimateLabel: string;
+  readonly statusLabel: string;
+  readonly statusColor: string;
+  readonly tasks: readonly SprintStoryTaskViewModel[];
+}
+
+export interface SprintOverviewViewModel {
+  readonly sprint: Sprint;
+  readonly periodLabel: string;
+  readonly totalPoints: number;
+  readonly plannedStories: number;
+  readonly completedStories: number;
+  readonly focus: string;
+  readonly stories: readonly SprintStoryViewModel[];
 }

--- a/src/app/features/sprints/README.md
+++ b/src/app/features/sprints/README.md
@@ -1,0 +1,22 @@
+# Sprints Feature
+
+## Objetivo
+Disponibilizar uma visão consolidada das sprints planejadas, com objetivos, foco estratégico e todas as histórias/tarefas que
+as compõem. A página funciona como um hub de alinhamento antes de plannings ou reviews.
+
+## Decisões técnicas
+- Reutilização do `BoardState` para garantir fonte única de verdade das histórias e do vínculo com sprints (`sprintOverviews`).
+- ViewModels prontos para consumo (`SprintOverviewViewModel`) evitam lógica no template e mantêm forte tipagem.
+- Layout responsivo com foco em leitura rápida: cards destacam objetivo, período e status das histórias.
+- Itens de checklist usam sinalização visual e texto escondido (`visually-hidden`) para reforçar acessibilidade.
+
+## Uso
+```ts
+import { SPRINTS_ROUTES } from '@features/sprints/sprints.routes';
+```
+As rotas lazy-loaded expõem `SprintsPageComponent`, que pode ser linkado pelo menu lateral (`/sprints`).
+
+## Checklist de manutenção
+- [ ] Sincronizar dados de sprint com a fonte oficial quando a API estiver disponível.
+- [ ] Validar contraste de cores das badges de status ao criar novos estados.
+- [ ] Incluir métricas adicionais (capacidade planejada, velocidade) conforme necessidade do time.

--- a/src/app/features/sprints/pages/sprints.page.html
+++ b/src/app/features/sprints/pages/sprints.page.html
@@ -1,0 +1,82 @@
+<section class="sprints" aria-labelledby="sprints-heading">
+  <header class="sprints__hero">
+    <h1 id="sprints-heading">Planejamento de sprints</h1>
+    <p>
+      Acompanhe o objetivo, o foco estratégico e todas as histórias previstas para cada sprint. Use este painel para alinhar o
+      squad antes das cerimônias e garantir que nenhuma tarefa épica fique de fora.
+    </p>
+  </header>
+
+  <section
+    *ngIf="hasSprints(); else emptySprints"
+    class="sprints__list"
+    aria-label="Sprints planejadas e suas histórias"
+  >
+    <article
+      *ngFor="let overview of sprintOverviews(); trackBy: trackSprint"
+      class="sprint"
+      [attr.aria-labelledby]="overview.sprint.id + '-title'"
+    >
+      <header class="sprint__header">
+        <div class="sprint__heading">
+          <h2 id="{{ overview.sprint.id + '-title' }}">{{ overview.sprint.name }}</h2>
+          <p class="sprint__goal">{{ overview.sprint.goal }}</p>
+        </div>
+        <dl class="sprint__meta">
+          <div>
+            <dt>Período</dt>
+            <dd>{{ overview.periodLabel }}</dd>
+          </div>
+          <div>
+            <dt>Histórias planejadas</dt>
+            <dd>{{ overview.plannedStories }}</dd>
+          </div>
+          <div>
+            <dt>Pontos totais</dt>
+            <dd>{{ overview.totalPoints }}</dd>
+          </div>
+          <div>
+            <dt>Histórias concluídas</dt>
+            <dd>{{ overview.completedStories }}</dd>
+          </div>
+        </dl>
+      </header>
+      <p class="sprint__focus" aria-label="Foco da sprint">{{ overview.focus }}</p>
+      <ul class="sprint__stories">
+        <li *ngFor="let story of overview.stories; trackBy: trackStory">
+          <article class="sprint-story" [attr.aria-labelledby]="story.id + '-title'">
+            <header class="sprint-story__header">
+              <h3 id="{{ story.id + '-title' }}">{{ story.title }}</h3>
+              <p class="sprint-story__meta">
+                <span class="sprint-story__status" [style.--status-color]="story.statusColor">{{ story.statusLabel }}</span>
+                <span aria-hidden="true">•</span>
+                <span>{{ story.estimateLabel }}</span>
+              </p>
+            </header>
+            <ul class="sprint-story__tasks" aria-label="Tarefas previstas">
+              <li
+                *ngFor="let task of story.tasks; trackBy: trackTask"
+                class="sprint-story__task"
+                [class.is-done]="task.isDone"
+              >
+                <span class="sprint-story__task-indicator" aria-hidden="true"></span>
+                <span class="sprint-story__task-title">{{ task.title }}</span>
+                <span class="visually-hidden">{{ task.isDone ? 'Concluída' : 'Pendente' }}</span>
+              </li>
+            </ul>
+          </article>
+        </li>
+      </ul>
+    </article>
+  </section>
+
+  <ng-template #emptySprints>
+    <section class="sprints__empty" aria-label="Sem sprints planejadas">
+      <h2>Nenhuma sprint cadastrada</h2>
+      <p>
+        Cadastre sprints no painel principal para começar a agrupar histórias e garantir que as missões prioritárias tenham uma
+        janela de entrega clara.
+      </p>
+    </section>
+  </ng-template>
+</section>

--- a/src/app/features/sprints/pages/sprints.page.scss
+++ b/src/app/features/sprints/pages/sprints.page.scss
@@ -1,0 +1,256 @@
+:host {
+  display: block;
+  min-height: 0;
+}
+
+.sprints {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  color: var(--hk-text-primary);
+}
+
+.sprints__hero {
+  background: var(--hk-surface);
+  border: 1px solid var(--hk-border);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 25px 50px -12px rgba(15, 12, 41, 0.4);
+}
+
+.sprints__hero > h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.8rem, 2.8vw, 2.6rem);
+  font-weight: 700;
+}
+
+.sprints__hero > p {
+  margin: 0;
+  color: var(--hk-text-muted);
+  max-width: 62ch;
+}
+
+.sprints__list {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.sprint {
+  display: grid;
+  gap: 1.5rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 2.6vw, 2.25rem);
+  box-shadow: 0 20px 45px -18px rgba(12, 10, 36, 0.55);
+}
+
+.sprint__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 880px) {
+  .sprint__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.sprint__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sprint__heading > h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.4vw, 2.1rem);
+  font-weight: 600;
+}
+
+.sprint__goal {
+  margin: 0;
+  color: var(--hk-text-secondary);
+  max-width: 46ch;
+}
+
+.sprint__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.sprint__meta > div {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+}
+
+.sprint__meta dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--hk-text-muted);
+}
+
+.sprint__meta dd {
+  margin: 0.3rem 0 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.sprint__focus {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(79, 70, 229, 0.18);
+  border: 1px solid rgba(79, 70, 229, 0.35);
+  color: var(--hk-text-primary);
+  font-weight: 500;
+}
+
+.sprint__stories {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.sprint-story {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1.25rem;
+  padding: 1.1rem 1.35rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.sprint-story__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+@media (min-width: 720px) {
+  .sprint-story__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.sprint-story__header > h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.sprint-story__meta {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--hk-text-muted);
+  font-size: 0.95rem;
+}
+
+.sprint-story__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  position: relative;
+  color: var(--hk-text-primary);
+}
+
+.sprint-story__status::before {
+  content: '';
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--status-color, #818cf8);
+}
+
+.sprint-story__tasks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.sprint-story__task {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.sprint-story__task:hover,
+.sprint-story__task:focus-visible {
+  border-color: rgba(124, 92, 255, 0.5);
+  background: rgba(124, 92, 255, 0.12);
+}
+
+.sprint-story__task-indicator {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.6);
+  background: transparent;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.sprint-story__task.is-done .sprint-story__task-indicator {
+  background: linear-gradient(135deg, #34d399 0%, #22d3ee 100%);
+  border-color: transparent;
+}
+
+.sprint-story__task-title {
+  color: var(--hk-text-primary);
+}
+
+.sprints__empty {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 1.5rem;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sprints__empty > h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.sprints__empty > p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/app/features/sprints/pages/sprints.page.ts
+++ b/src/app/features/sprints/pages/sprints.page.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { BoardState } from '../../board/state/board-state.service';
+
+@Component({
+  selector: 'hk-sprints-page',
+  standalone: true,
+  templateUrl: './sprints.page.html',
+  styleUrls: ['./sprints.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgFor, NgIf],
+})
+export class SprintsPageComponent {
+  private readonly boardState = inject(BoardState);
+
+  protected readonly sprintOverviews = this.boardState.sprintOverviews;
+  protected readonly trackSprint = this.boardState.trackSprintOverview;
+  protected readonly trackStory = this.boardState.trackSprintStory;
+  protected readonly trackTask = this.boardState.trackSprintTask;
+  protected readonly hasSprints = computed(() => this.sprintOverviews().length > 0);
+}

--- a/src/app/features/sprints/sprints.routes.ts
+++ b/src/app/features/sprints/sprints.routes.ts
@@ -1,0 +1,10 @@
+import { Routes } from '@angular/router';
+import { SprintsPageComponent } from './pages/sprints.page';
+
+export const SPRINTS_ROUTES: Routes = [
+  {
+    path: '',
+    component: SprintsPageComponent,
+    title: 'Hero Kanban — Planejamento de Sprints',
+  },
+];


### PR DESCRIPTION
## Summary
- model sprints inside BoardState, expose filtering signals, and cover behaviour with unit tests
- build a standalone sprints feature page with navigation/menu entries and documentation
- drop the Angular Material dependency by replacing the add icon styling and removing the prebuilt theme import

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: No binary for ChromeHeadless browser on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68dddc9111cc8333a7560d0973cd5c1d