### PR TITLE
feat: add story details page and task shortcuts

### DIFF
--- a/src/app/features/board/board.routes.ts
+++ b/src/app/features/board/board.routes.ts
@@ -1,10 +1,17 @@
 import { Routes } from '@angular/router';
 import { BoardPageComponent } from './pages/board.page';
+import { StoryDetailsPageComponent } from './pages/story-details/story-details.page';
 
 export const BOARD_ROUTES: Routes = [
   {
+    path: 'historia/:storyId',
+    component: StoryDetailsPageComponent,
+    title: 'Hero Kanban — Detalhes da história',
+  },
+  {
     path: '',
     component: BoardPageComponent,
+    pathMatch: 'full',
     title: 'Hero Kanban — Missões do Time',
   },
 ];

--- a/src/app/features/board/components/board-card/board-card.component.html
+++ b/src/app/features/board/components/board-card/board-card.component.html
@@ -3,9 +3,14 @@
   [class.card--dragging]="isDragging()"
   [attr.data-priority]="card().priorityLabel"
   [attr.aria-grabbed]="isDragging()"
+  [attr.aria-label]="card().title + ' — ' + card().featureName"
+  role="button"
+  tabindex="0"
   draggable="true"
   (dragstart)="onDragStart($event)"
   (dragend)="onDragEnd()"
+  (click)="openDetails()"
+  (keydown)="handleKeydown($event)"
 >
   <header class="card__header">
     <span class="card__priority" [style.background]="card().priorityColor">{{ card().priorityLabel }}</span>

--- a/src/app/features/board/components/board-card/board-card.component.scss
+++ b/src/app/features/board/components/board-card/board-card.component.scss
@@ -9,12 +9,20 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   cursor: grab;
   user-select: none;
+  outline: none;
 }
 
 .card:hover,
-.card:focus-within {
+.card:focus-within,
+.card:focus-visible {
   transform: translateY(-3px);
   box-shadow: 0 18px 40px -12px rgba(14, 11, 36, 0.8);
+}
+
+.card:focus-visible {
+  box-shadow:
+    0 18px 40px -12px rgba(14, 11, 36, 0.8),
+    0 0 0 3px rgba(99, 102, 241, 0.6);
 }
 
 .card--dragging {

--- a/src/app/features/board/components/board-card/board-card.component.ts
+++ b/src/app/features/board/components/board-card/board-card.component.ts
@@ -3,6 +3,7 @@ import { NgFor, NgIf } from '@angular/common';
 import type { BoardCardViewModel } from '../../state/board.models';
 import { BoardDragState } from '../../state/board-drag-state.service';
 import { STORY_ID_MIME_TYPE, STORY_STATUS_MIME_TYPE } from '../board-dnd.constants';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'kanban-board-card',
@@ -17,6 +18,7 @@ export class BoardCardComponent {
   protected readonly isDragging = signal(false);
 
   private readonly dragState = inject(BoardDragState);
+  private readonly router = inject(Router);
 
   protected onDragStart(event: DragEvent): void {
     const card = this.card();
@@ -35,5 +37,17 @@ export class BoardCardComponent {
   protected onDragEnd(): void {
     this.dragState.endDrag();
     this.isDragging.set(false);
+  }
+
+  protected openDetails(): void {
+    const card = this.card();
+    void this.router.navigate(['/historia', card.id]);
+  }
+
+  protected handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.openDetails();
+    }
   }
 }

--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -5,10 +5,16 @@
         <h1 id="board-heading">Missões em andamento</h1>
         <p>Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.</p>
       </div>
-      <button type="button" class="board__new-story" (click)="openCreateStory()">
-        <span class="board__new-story-icon" aria-hidden="true">add_circle</span>
-        Nova história
-      </button>
+      <div class="board__actions" role="group" aria-label="Ações rápidas do quadro">
+        <button type="button" class="board__new-story" (click)="openCreateStory()">
+          <span class="board__new-story-icon" aria-hidden="true">add_circle</span>
+          Nova história
+        </button>
+        <button type="button" class="board__new-task">
+          <span class="board__new-task-icon" aria-hidden="true">playlist_add</span>
+          Nova tarefa
+        </button>
+      </div>
     </div>
     <div class="board__progress" role="status" aria-live="polite">
       <div class="board__level">Guilda nível {{ summary().level }}</div>

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -32,6 +32,13 @@
   gap: 1rem;
 }
 
+.board__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
 .board__intro-text > h1 {
   margin: 0;
   font-size: clamp(1.6rem, 2.8vw, 2.4rem);
@@ -49,10 +56,15 @@
     align-items: center;
     justify-content: space-between;
   }
+
+  .board__actions {
+    flex-direction: row;
+  }
 }
 
 @media (max-width: 719px) {
-  .board__new-story {
+  .board__new-story,
+  .board__new-task {
     width: 100%;
     justify-content: center;
   }
@@ -85,6 +97,36 @@
 .board__new-story:focus-visible {
   transform: translateY(-1px);
   filter: brightness(1.05);
+}
+
+.board__new-task {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: rgba(79, 70, 229, 0.12);
+  color: #e0e7ff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.board__new-task-icon {
+  font-family: 'Material Symbols Rounded';
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.board__new-task:hover,
+.board__new-task:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(129, 140, 248, 0.75);
+  background: rgba(99, 102, 241, 0.2);
 }
 
 .board__progress {

--- a/src/app/features/board/pages/story-details/story-details.page.html
+++ b/src/app/features/board/pages/story-details/story-details.page.html
@@ -1,0 +1,108 @@
+<section
+  *ngIf="story() as details; else notFound"
+  class="story-details"
+  aria-labelledby="story-details-title"
+>
+  <header class="story-details__toolbar">
+    <a routerLink="/" class="story-details__back">
+      <span class="material-symbols-rounded" aria-hidden="true">arrow_back</span>
+      Voltar para o quadro
+    </a>
+    <button type="button" class="story-details__new-task">
+      <span class="material-symbols-rounded" aria-hidden="true">playlist_add</span>
+      Nova tarefa
+    </button>
+  </header>
+
+  <article class="story-details__content">
+    <header class="story-details__summary">
+      <span class="story-details__status" [style.--status-color]="details.statusColor">
+        <span class="material-symbols-rounded" aria-hidden="true">{{ details.statusIcon }}</span>
+        <span class="story-details__status-label">{{ details.statusLabel }}</span>
+      </span>
+      <p class="story-details__status-description">{{ details.statusDescription }}</p>
+      <h1 id="story-details-title">{{ details.title }}</h1>
+      <p class="story-details__theme">Tema: {{ details.featureTheme }}</p>
+      <p class="story-details__mission">{{ details.featureMission }}</p>
+    </header>
+
+    <section class="story-details__meta" aria-label="Informações gerais da história">
+      <div>
+        <span class="story-details__meta-label">Responsável</span>
+        <div class="story-details__assignee">
+          <span class="story-details__avatar" aria-hidden="true">{{ details.avatarInitials }}</span>
+          <span>{{ details.assignee }}</span>
+        </div>
+      </div>
+      <div>
+        <span class="story-details__meta-label">Prioridade</span>
+        <span class="story-details__priority" [style.background]="details.priorityColor">
+          {{ details.priorityLabel }}
+        </span>
+      </div>
+      <div>
+        <span class="story-details__meta-label">Estimativa</span>
+        <span>{{ details.estimateLabel }}</span>
+      </div>
+      <div>
+        <span class="story-details__meta-label">Recompensa</span>
+        <span>{{ details.xp }} XP</span>
+      </div>
+      <div>
+        <span class="story-details__meta-label">Feature</span>
+        <span>{{ details.featureName }}</span>
+      </div>
+      <div *ngIf="details.dueLabel as due">
+        <span class="story-details__meta-label">Entrega</span>
+        <span>{{ due }}</span>
+      </div>
+      <div *ngIf="details.sprintLabel as sprint">
+        <span class="story-details__meta-label">Sprint</span>
+        <span>{{ sprint }}</span>
+      </div>
+    </section>
+
+    <section class="story-details__labels" *ngIf="details.labels.length > 0" aria-label="Etiquetas">
+      <h2>Etiquetas</h2>
+      <ul>
+        <li *ngFor="let label of details.labels">{{ label }}</li>
+      </ul>
+    </section>
+
+    <section class="story-details__tasks" aria-label="Tarefas associadas">
+      <header class="story-details__tasks-header">
+        <h2>Tarefas</h2>
+        <p>{{ details.checklistProgressLabel }}</p>
+      </header>
+      <div
+        class="story-details__tasks-progress"
+        role="img"
+        [attr.aria-label]="'Progresso de checklist ' + details.checklistProgressLabel"
+      >
+        <span class="story-details__tasks-progress-fill" [style.width.%]="details.completionPercent"></span>
+      </div>
+      <ul>
+        <li
+          *ngFor="let task of details.tasks; trackBy: trackTask"
+          class="story-details__task"
+          [class.is-done]="task.isDone"
+        >
+          <span class="story-details__task-indicator" aria-hidden="true"></span>
+          <span class="story-details__task-title">{{ task.title }}</span>
+          <span class="visually-hidden">{{ task.isDone ? 'Concluída' : 'Pendente' }}</span>
+        </li>
+      </ul>
+    </section>
+  </article>
+</section>
+
+<ng-template #notFound>
+  <section class="story-details story-details--empty" aria-labelledby="story-details-missing">
+    <h1 id="story-details-missing">História não encontrada</h1>
+    <p>Não encontramos a missão selecionada. Ela pode ter sido arquivada ou removida do quadro.</p>
+    <a routerLink="/" class="story-details__back">
+      <span class="material-symbols-rounded" aria-hidden="true">arrow_back</span>
+      Voltar para o quadro
+    </a>
+  </section>
+</ng-template>

--- a/src/app/features/board/pages/story-details/story-details.page.scss
+++ b/src/app/features/board/pages/story-details/story-details.page.scss
@@ -1,0 +1,309 @@
+:host {
+  display: block;
+  min-height: 0;
+}
+
+.story-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  background: var(--hk-surface);
+  border: 1px solid var(--hk-border);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 30px 60px -28px rgba(13, 10, 36, 0.65);
+  color: var(--hk-text-primary);
+}
+
+.story-details__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.story-details__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: #bfdbfe;
+  background: rgba(37, 99, 235, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  font-weight: 600;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.story-details__back:hover,
+.story-details__back:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(59, 130, 246, 0.28);
+  border-color: rgba(59, 130, 246, 0.55);
+}
+
+.story-details__new-task {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(217, 70, 239, 0.4);
+  background: rgba(236, 72, 153, 0.18);
+  color: #fbcfe8;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.story-details__new-task:hover,
+.story-details__new-task:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(236, 72, 153, 0.6);
+  background: rgba(236, 72, 153, 0.28);
+}
+
+.story-details__content {
+  display: grid;
+  gap: 2rem;
+}
+
+.story-details__summary {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.story-details__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: var(--hk-text-primary);
+  position: relative;
+}
+
+.story-details__status::before {
+  content: '';
+  position: absolute;
+  inset: auto auto 0 0;
+  width: 100%;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--status-color, #6366f1);
+  opacity: 0.6;
+}
+
+.story-details__status-label {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.story-details__status-description {
+  margin: 0;
+  color: var(--hk-text-muted);
+  font-size: 0.9rem;
+}
+
+.story-details__summary > h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 700;
+}
+
+.story-details__theme {
+  margin: 0;
+  color: var(--hk-text-secondary);
+  font-weight: 500;
+}
+
+.story-details__mission {
+  margin: 0;
+  color: var(--hk-text-muted);
+  max-width: 65ch;
+}
+
+.story-details__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.story-details__meta > div {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.story-details__meta-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--hk-text-muted);
+}
+
+.story-details__assignee {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.story-details__avatar {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #4f46e5 0%, #38bdf8 100%);
+  font-weight: 600;
+}
+
+.story-details__priority {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.story-details__labels {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.story-details__labels > h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.story-details__labels > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.story-details__labels > ul > li {
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.85rem;
+}
+
+.story-details__tasks {
+  display: grid;
+  gap: 1rem;
+}
+
+.story-details__tasks-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.story-details__tasks-header > h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.story-details__tasks-header > p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.story-details__tasks-progress {
+  position: relative;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.story-details__tasks-progress-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #34d399 0%, #60a5fa 100%);
+  transition: width 0.3s ease;
+}
+
+.story-details__tasks > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.story-details__task {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.story-details__task.is-done {
+  border-color: rgba(74, 222, 128, 0.55);
+  background: rgba(74, 222, 128, 0.12);
+}
+
+.story-details__task-indicator {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.6);
+}
+
+.story-details__task.is-done .story-details__task-indicator {
+  background: linear-gradient(135deg, #34d399 0%, #22d3ee 100%);
+}
+
+.story-details__task-title {
+  font-weight: 500;
+}
+
+.story-details--empty {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.story-details--empty > h1 {
+  margin: 0 0 0.5rem;
+}
+
+.story-details--empty > p {
+  margin: 0 0 1.25rem;
+  color: var(--hk-text-muted);
+}
+
+@media (max-width: 719px) {
+  .story-details__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .story-details__new-task,
+  .story-details__back {
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/src/app/features/board/pages/story-details/story-details.page.ts
+++ b/src/app/features/board/pages/story-details/story-details.page.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+import { BoardState } from '../../state/board-state.service';
+import type { StoryDetailsTaskViewModel } from '../../state/board.models';
+
+@Component({
+  selector: 'hk-story-details-page',
+  standalone: true,
+  templateUrl: './story-details.page.html',
+  styleUrls: ['./story-details.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIf, NgFor, RouterLink],
+})
+export class StoryDetailsPageComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly boardState = inject(BoardState);
+
+  private readonly storyId = toSignal(
+    this.route.paramMap.pipe(map((params) => params.get('storyId'))),
+    { initialValue: null },
+  );
+
+  protected readonly story = computed(() => {
+    const id = this.storyId();
+    return id ? this.boardState.getStoryDetails(id) : null;
+  });
+
+  protected trackTask(_: number, task: StoryDetailsTaskViewModel): string {
+    return task.id;
+  }
+}

--- a/src/app/features/board/state/board.models.ts
+++ b/src/app/features/board/state/board.models.ts
@@ -158,3 +158,35 @@ export interface SprintOverviewViewModel {
   readonly focus: string;
   readonly stories: readonly SprintStoryViewModel[];
 }
+
+export interface StoryDetailsTaskViewModel {
+  readonly id: string;
+  readonly title: string;
+  readonly isDone: boolean;
+}
+
+export interface StoryDetailsViewModel {
+  readonly id: string;
+  readonly title: string;
+  readonly featureName: string;
+  readonly featureTheme: string;
+  readonly featureMission: string;
+  readonly statusLabel: string;
+  readonly statusDescription: string;
+  readonly statusColor: string;
+  readonly statusIcon: string;
+  readonly priorityLabel: string;
+  readonly priorityColor: string;
+  readonly assignee: string;
+  readonly avatarInitials: string;
+  readonly estimateLabel: string;
+  readonly xp: number;
+  readonly labels: readonly string[];
+  readonly dueLabel?: string;
+  readonly sprintLabel?: string;
+  readonly tasks: readonly StoryDetailsTaskViewModel[];
+  readonly completedTasks: number;
+  readonly totalTasks: number;
+  readonly checklistProgressLabel: string;
+  readonly completionPercent: number;
+}

--- a/src/app/features/sprints/pages/sprints.page.html
+++ b/src/app/features/sprints/pages/sprints.page.html
@@ -1,10 +1,16 @@
 <section class="sprints" aria-labelledby="sprints-heading">
   <header class="sprints__hero">
-    <h1 id="sprints-heading">Planejamento de sprints</h1>
-    <p>
-      Acompanhe o objetivo, o foco estratégico e todas as histórias previstas para cada sprint. Use este painel para alinhar o
-      squad antes das cerimônias e garantir que nenhuma tarefa épica fique de fora.
-    </p>
+    <div class="sprints__hero-heading">
+      <h1 id="sprints-heading">Planejamento de sprints</h1>
+      <p>
+        Acompanhe o objetivo, o foco estratégico e todas as histórias previstas para cada sprint. Use este painel para alinhar o
+        squad antes das cerimônias e garantir que nenhuma tarefa épica fique de fora.
+      </p>
+    </div>
+    <button type="button" class="sprints__new-task">
+      <span class="sprints__new-task-icon" aria-hidden="true">playlist_add</span>
+      Nova tarefa
+    </button>
   </header>
 
   <section

--- a/src/app/features/sprints/pages/sprints.page.scss
+++ b/src/app/features/sprints/pages/sprints.page.scss
@@ -11,6 +11,9 @@
 }
 
 .sprints__hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
   background: var(--hk-surface);
   border: 1px solid var(--hk-border);
   border-radius: 1.5rem;
@@ -18,16 +21,66 @@
   box-shadow: 0 25px 50px -12px rgba(15, 12, 41, 0.4);
 }
 
-.sprints__hero > h1 {
-  margin: 0 0 0.75rem;
+.sprints__hero-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sprints__hero-heading > h1 {
+  margin: 0;
   font-size: clamp(1.8rem, 2.8vw, 2.6rem);
   font-weight: 700;
 }
 
-.sprints__hero > p {
+.sprints__hero-heading > p {
   margin: 0;
   color: var(--hk-text-muted);
   max-width: 62ch;
+}
+
+.sprints__new-task {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 118, 110, 0.4);
+  background: rgba(13, 148, 136, 0.18);
+  color: #ccfbf1;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.sprints__new-task:hover,
+.sprints__new-task:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(20, 184, 166, 0.65);
+  background: rgba(20, 184, 166, 0.25);
+}
+
+.sprints__new-task-icon {
+  font-family: 'Material Symbols Rounded';
+  font-weight: 400;
+  font-style: normal;
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+@media (min-width: 720px) {
+  .sprints__hero {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 719px) {
+  .sprints__new-task {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 .sprints__list {


### PR DESCRIPTION
## Summary
- add a standalone story details page and routing entry to expose story metadata and tasks
- map board state data into dedicated detail view models for the new page
- update board cards and major pages with accessible navigation and "Nova tarefa" quick actions

## Testing
- npm run build *(fails: external font download returned status 400 during asset inlining)*

------
https://chatgpt.com/codex/tasks/task_e_68dde6639dc883339ff71f53bc94c7c2