### PR TITLE
style: restore board spacing after material upgrade

### DIFF
--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -14,6 +14,8 @@
   background: rgba(20, 22, 42, 0.82);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 24px 40px -18px rgba(10, 8, 30, 0.55);
+  border-radius: 1.25rem;
+  overflow: hidden;
 }
 
 .board__summary-avatar {
@@ -30,6 +32,26 @@
   align-items: start;
 }
 
+.board__summary :is(.mat-mdc-card-header, .mat-mdc-card-content) {
+  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.board__summary .mat-mdc-card-header {
+  padding-block: clamp(1.25rem, 3vw, 1.75rem) 1.25rem;
+  gap: 1rem;
+  align-items: center;
+}
+
+.board__summary .mat-mdc-card-content {
+  padding-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.board__summary .mat-mdc-card-avatar {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 1rem;
+}
+
 .board__actions {
   display: flex;
   flex-direction: column;
@@ -42,9 +64,25 @@
   }
 }
 
+.board__actions button[mat-flat-button],
+.board__actions button[mat-stroked-button] {
+  min-height: 3rem;
+  padding-inline: 1.25rem;
+  font-weight: 600;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .board__progress {
   display: grid;
   gap: 0.75rem;
+}
+
+.board__progress mat-progress-bar {
+  --mdc-linear-progress-track-thickness: 0.65rem;
+  border-radius: 999px;
 }
 
 .board__progress > p {
@@ -69,6 +107,17 @@
   gap: 0.5rem;
 }
 
+.board__stats mat-chip {
+  padding-inline: 0.85rem;
+  height: auto;
+  min-height: 2.5rem;
+  border-radius: 999px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
 .board__filters {
   display: flex;
   flex-direction: column;
@@ -77,11 +126,31 @@
 
 .board__filter {
   width: min(280px, 100%);
+  --mat-form-field-container-height: 3.1rem;
+  --mdc-filled-text-field-container-shape: 1rem;
+  --mdc-outlined-text-field-container-shape: 1rem;
 }
 
 .board__missions {
   background: rgba(20, 22, 42, 0.82);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.board__missions :is(.mat-mdc-card-header, .mat-mdc-card-content) {
+  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.board__missions .mat-mdc-card-header {
+  padding-block: clamp(1.25rem, 3vw, 1.75rem) 1rem;
+  gap: 0.75rem;
+}
+
+.board__missions .mat-mdc-card-content {
+  padding-bottom: clamp(1.25rem, 4vw, 2.25rem);
+  display: grid;
+  gap: 0.5rem;
 }
 
 .mission {
@@ -123,7 +192,7 @@
 }
 
 .mission__progress {
-  height: 0.5rem;
+  --mdc-linear-progress-track-thickness: 0.6rem;
   border-radius: 999px;
 }
 


### PR DESCRIPTION
## Summary
- restore the spacing rhythm on the board summary and missions cards so Material 3 paddings match the original design intent
- retune quick actions, chips and progress bars to regain the roomy proportions from before the Angular Material update

## Testing
- npm run build *(fails: Google Fonts CDN returns HTTP 400 when inlining fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf140dfd08333be888852d0f9bd19