### PR TITLE
fix: restore missions layout and reposition sprint filter

### DIFF
--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -1,98 +1,104 @@
 <section class="board" aria-labelledby="board-heading">
-  <mat-card class="board__summary">
-    <mat-card-header>
-      <div mat-card-avatar class="board__summary-avatar">
-        <mat-icon>view_kanban</mat-icon>
-      </div>
-      <mat-card-title id="board-heading">Missões em andamento</mat-card-title>
-      <mat-card-subtitle>
-        Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.
-      </mat-card-subtitle>
-    </mat-card-header>
-
-    <mat-card-content>
-      <div class="board__summary-grid">
-        <div class="board__actions" role="group" aria-label="Ações rápidas do quadro">
-          <button type="button" mat-flat-button color="primary" (click)="openCreateStory()">
-            <mat-icon>add_circle</mat-icon>
-            Nova história
-          </button>
-          <button type="button" mat-stroked-button color="accent">
-            <mat-icon>playlist_add</mat-icon>
-            Nova tarefa
-          </button>
+  <div class="board__overview">
+    <mat-card class="board__summary">
+      <mat-card-header>
+        <div mat-card-avatar class="board__summary-avatar">
+          <mat-icon>view_kanban</mat-icon>
         </div>
+        <mat-card-title id="board-heading">Missões em andamento</mat-card-title>
+        <mat-card-subtitle>
+          Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.
+        </mat-card-subtitle>
+      </mat-card-header>
 
-        <div class="board__progress" role="status" aria-live="polite">
-          <mat-chip-set class="board__level-chip">
-            <mat-chip color="primary" selected>
-              <mat-icon matChipAvatar>workspace_premium</mat-icon>
-              Guilda nível {{ summary().level }}
-            </mat-chip>
-          </mat-chip-set>
-          <mat-progress-bar mode="determinate" [value]="summary().xpProgressPercent"></mat-progress-bar>
-          <p>
-            {{ summary().xpEarned }} XP acumulado · faltam {{ summary().xpToNextLevel }} XP para o próximo emblema
-          </p>
-        </div>
+      <mat-card-content>
+        <div class="board__summary-grid">
+          <div class="board__actions" role="group" aria-label="Ações rápidas do quadro">
+            <button type="button" mat-flat-button color="primary" (click)="openCreateStory()">
+              <mat-icon>add_circle</mat-icon>
+              Nova história
+            </button>
+            <button type="button" mat-stroked-button color="accent">
+              <mat-icon>playlist_add</mat-icon>
+              Nova tarefa
+            </button>
+          </div>
 
-        <mat-divider class="board__divider"></mat-divider>
+          <div class="board__progress" role="status" aria-live="polite">
+            <mat-chip-set class="board__level-chip">
+              <mat-chip color="primary" selected>
+                <mat-icon matChipAvatar>workspace_premium</mat-icon>
+                Guilda nível {{ summary().level }}
+              </mat-chip>
+            </mat-chip-set>
+            <mat-progress-bar mode="determinate" [value]="summary().xpProgressPercent"></mat-progress-bar>
+            <p>
+              {{ summary().xpEarned }} XP acumulado · faltam {{ summary().xpToNextLevel }} XP para o próximo emblema
+            </p>
+          </div>
 
-        <div class="board__stats">
-          <mat-chip-set>
-            <mat-chip variant="outlined">
-              <mat-icon matChipAvatar>task_alt</mat-icon>
-              Histórias concluídas: {{ summary().completedStories }}
-            </mat-chip>
-            <mat-chip variant="outlined">
-              <mat-icon matChipAvatar>hub</mat-icon>
-              Features ativas: {{ summary().activeFeatures }}
-            </mat-chip>
-            <mat-chip variant="outlined">
-              <mat-icon matChipAvatar>monitoring</mat-icon>
-              Throughput semanal: {{ summary().weeklyThroughput }}
-            </mat-chip>
-          </mat-chip-set>
-        </div>
+          <mat-divider class="board__divider"></mat-divider>
 
-        <div class="board__filters" role="region" aria-label="Filtros do quadro">
-          <mat-form-field appearance="fill" class="board__filter">
-            <mat-label>Sprint</mat-label>
-            <mat-select [value]="selectedSprintId()" (valueChange)="onSprintFilterSelected($event)">
-              <mat-option *ngFor="let option of sprintOptions()" [value]="option.id">
-                {{ option.label }}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
-      </div>
-    </mat-card-content>
-  </mat-card>
-
-  <mat-card *ngIf="summary().missions.length > 0" class="board__missions" aria-label="Missões em destaque">
-    <mat-card-header>
-      <mat-card-title>Missões</mat-card-title>
-      <mat-card-subtitle>Objetivos que destravam recompensas extras para a guilda.</mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      <div class="mission" *ngFor="let mission of summary().missions">
-        <div class="mission__info">
-          <mat-icon aria-hidden="true">auto_awesome</mat-icon>
-          <div>
-            <p class="mission__title">{{ mission.title }}</p>
-            <p class="mission__target">{{ mission.target }}</p>
+          <div class="board__stats">
+            <mat-chip-set>
+              <mat-chip variant="outlined">
+                <mat-icon matChipAvatar>task_alt</mat-icon>
+                Histórias concluídas: {{ summary().completedStories }}
+              </mat-chip>
+              <mat-chip variant="outlined">
+                <mat-icon matChipAvatar>hub</mat-icon>
+                Features ativas: {{ summary().activeFeatures }}
+              </mat-chip>
+              <mat-chip variant="outlined">
+                <mat-icon matChipAvatar>monitoring</mat-icon>
+                Throughput semanal: {{ summary().weeklyThroughput }}
+              </mat-chip>
+            </mat-chip-set>
           </div>
         </div>
-        <span class="mission__reward">{{ mission.reward }}</span>
-        <mat-progress-bar
-          class="mission__progress"
-          mode="determinate"
-          [value]="mission.progress * 100"
-          [attr.aria-label]="'Progresso ' + (mission.progress * 100 | number: '1.0-0') + '%'"
-        ></mat-progress-bar>
-      </div>
-    </mat-card-content>
-  </mat-card>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card *ngIf="summary().missions.length > 0" class="board__missions" aria-label="Missões em destaque">
+      <mat-card-header>
+        <mat-card-title>Missões</mat-card-title>
+        <mat-card-subtitle>Objetivos que destravam recompensas extras para a guilda.</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="board__missions-list">
+          <article class="mission" *ngFor="let mission of summary().missions">
+            <div class="mission__info">
+              <mat-icon aria-hidden="true">auto_awesome</mat-icon>
+              <div>
+                <p class="mission__title">{{ mission.title }}</p>
+                <p class="mission__target">{{ mission.target }}</p>
+              </div>
+            </div>
+            <span class="mission__reward">{{ mission.reward }}</span>
+            <mat-progress-bar
+              class="mission__progress"
+              mode="determinate"
+              [value]="mission.progress * 100"
+              [attr.aria-label]="'Progresso ' + (mission.progress * 100 | number: '1.0-0') + '%'"
+            ></mat-progress-bar>
+          </article>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+
+  <section class="board__toolbar" aria-label="Filtros das tarefas">
+    <div class="board__filters" role="region" aria-label="Filtrar tarefas por sprint">
+      <mat-form-field appearance="fill" class="board__filter">
+        <mat-label>Sprint</mat-label>
+        <mat-select [value]="selectedSprintId()" (valueChange)="onSprintFilterSelected($event)">
+          <mat-option *ngFor="let option of sprintOptions()" [value]="option.id">
+            {{ option.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </section>
 
   <section class="board__columns" role="list">
     <kanban-board-column

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -10,6 +10,18 @@
   color: var(--hk-text-primary);
 }
 
+.board__overview {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+@media (min-width: 1120px) {
+  .board__overview {
+    grid-template-columns: minmax(0, 2.15fr) minmax(0, 1.35fr);
+    align-items: stretch;
+  }
+}
+
 .board__summary {
   background: rgba(20, 22, 42, 0.82);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -118,6 +130,13 @@
   gap: 0.45rem;
 }
 
+
+.board__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding-inline: clamp(0.5rem, 4vw, 2.25rem);
+}
+
 .board__filters {
   display: flex;
   flex-direction: column;
@@ -136,6 +155,8 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 1.25rem;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .board__missions :is(.mat-mdc-card-header, .mat-mdc-card-content) {
@@ -149,6 +170,11 @@
 
 .board__missions .mat-mdc-card-content {
   padding-bottom: clamp(1.25rem, 4vw, 2.25rem);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.board__missions-list {
   display: grid;
   gap: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- restore the missions highlight card so it sits alongside the "Missões em andamento" overview instead of being nested
- add a dedicated toolbar above the task columns and move the sprint filter there for clearer context
- tweak board page styles to support the side-by-side layout and refreshed missions card spacing

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Rounded:FILL@1,opsz@24&display=swap returned status code: 400)*

------
https://chatgpt.com/codex/tasks/task_e_68de7681ace08333b203920536ef4458