### PR TITLE
Add theme selector to hero profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Os testes cobrem o shell principal e regras de negócio dos serviços de estado 
 
 ### Organização
 
-- `core/`: estado global do herói e serviços utilitários compartilhados.
+- `core/`: estado global do herói, gerenciamento de tema e serviços utilitários compartilhados.
 - `features/`: cada domínio (quadro, sprints, perfil, etc.) expõe componentes standalone, rotas lazy e serviços próprios.
 - Componentes e estados são tipados (`BoardColumnViewModel`, `Story`, `SprintOverviewViewModel`) para evitar `any`.
 
@@ -63,6 +63,7 @@ Os testes cobrem o shell principal e regras de negócio dos serviços de estado 
 
 ### Perfil do herói (`/perfil`)
 - Consome `HeroControlState` para mostrar nível, conquistas e itens obtidos pela guilda.
+- `ThemeState` habilita seleção dinâmica entre os temas **Noite Estelar** e **Aurora Boreal**, atualizando tokens de cor globais.
 - Componentização standalone facilita futuras expansões como loja ou ranking.
 
 ## Próximos passos sugeridos

--- a/src/app/core/state/theme.state.spec.ts
+++ b/src/app/core/state/theme.state.spec.ts
@@ -1,0 +1,39 @@
+import { DOCUMENT } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+
+import { ThemeState } from './theme.state';
+
+describe('ThemeState', () => {
+  let state: ThemeState;
+  let documentRef: Document;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    documentRef = TestBed.inject(DOCUMENT);
+    documentRef.documentElement.dataset['theme'] = '';
+    state = TestBed.inject(ThemeState);
+  });
+
+  afterEach(() => {
+    documentRef.documentElement.dataset['theme'] = '';
+  });
+
+  it('should expose the default theme and apply it to the document', () => {
+    expect(state.currentTheme()).toBe('stellar-night');
+    expect(documentRef.documentElement.dataset['theme']).toBe('stellar-night');
+  });
+
+  it('should change the theme when a valid option is selected', () => {
+    state.setTheme('aurora-crest');
+
+    expect(state.currentTheme()).toBe('aurora-crest');
+    expect(documentRef.documentElement.dataset['theme']).toBe('aurora-crest');
+  });
+
+  it('should ignore unknown theme identifiers', () => {
+    state.setTheme('aurora-crest');
+    state.setTheme('unknown-theme' as never);
+
+    expect(state.currentTheme()).toBe('aurora-crest');
+  });
+});

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -1,0 +1,74 @@
+import { DOCUMENT } from '@angular/common';
+import { inject, Injectable, signal } from '@angular/core';
+
+export type ThemeId = 'stellar-night' | 'aurora-crest';
+
+export interface ThemeOption {
+  readonly id: ThemeId;
+  readonly label: string;
+  readonly description: string;
+  readonly accent: string;
+  readonly softAccent: string;
+  readonly previewGradient: string;
+  readonly tone: 'dark' | 'light';
+}
+
+@Injectable({ providedIn: 'root' })
+export class ThemeState {
+  private readonly documentRef = inject(DOCUMENT);
+
+  private readonly _themes = signal<readonly ThemeOption[]>([
+    {
+      id: 'stellar-night',
+      label: 'Noite Estelar',
+      description: 'Tema original com tons profundos e acento violeta.',
+      accent: '#7c5cff',
+      softAccent: 'rgba(124, 92, 255, 0.28)',
+      previewGradient: 'linear-gradient(135deg, #1b1933 0%, #433978 100%)',
+      tone: 'dark',
+    },
+    {
+      id: 'aurora-crest',
+      label: 'Aurora Boreal',
+      description: 'Mistura esmeralda e azul para uma interface energizante.',
+      accent: '#1dd3b0',
+      softAccent: 'rgba(29, 211, 176, 0.25)',
+      previewGradient: 'linear-gradient(135deg, #012a4a 0%, #036666 100%)',
+      tone: 'dark',
+    },
+  ]);
+
+  private readonly _currentTheme = signal<ThemeId>('stellar-night');
+
+  readonly themes = this._themes.asReadonly();
+  readonly currentTheme = this._currentTheme.asReadonly();
+
+  constructor() {
+    this.applyTheme(this._currentTheme());
+  }
+
+  setTheme(themeId: ThemeId): void {
+    if (this._currentTheme() === themeId) {
+      return;
+    }
+
+    const isKnownTheme = this._themes().some((theme) => theme.id === themeId);
+
+    if (!isKnownTheme) {
+      return;
+    }
+
+    this._currentTheme.set(themeId);
+    this.applyTheme(themeId);
+  }
+
+  private applyTheme(themeId: ThemeId): void {
+    const rootElement = this.documentRef?.documentElement;
+
+    if (!rootElement) {
+      return;
+    }
+
+    rootElement.dataset['theme'] = themeId;
+  }
+}

--- a/src/app/features/profile/pages/profile.page.html
+++ b/src/app/features/profile/pages/profile.page.html
@@ -18,6 +18,41 @@
     </div>
   </section>
 
+  <section class="profile__theme" aria-labelledby="theme-heading">
+    <header>
+      <h2 id="theme-heading">Personalizar tema</h2>
+      <p>Escolha uma paleta visual para combinar com a energia da guilda.</p>
+    </header>
+    <ul class="theme-options" role="radiogroup" [attr.aria-labelledby]="'theme-heading'">
+      <li *ngFor="let theme of themes(); trackBy: trackTheme" class="theme-options__item">
+        <input
+          type="radio"
+          class="theme-option__input"
+          name="theme-selection"
+          [id]="'theme-' + theme.id"
+          [value]="theme.id"
+          [checked]="isThemeSelected(theme.id)"
+          (change)="onThemeSelect(theme.id)"
+        />
+        <label
+          class="theme-option__card"
+          [attr.for]="'theme-' + theme.id"
+          [class.theme-option__card--active]="isThemeSelected(theme.id)"
+          [style.--theme-accent]="theme.accent"
+          [style.--theme-soft-accent]="theme.softAccent"
+          [style.--theme-preview]="theme.previewGradient"
+        >
+          <span class="theme-option__preview" aria-hidden="true"></span>
+          <span class="theme-option__content">
+            <span class="theme-option__title">{{ theme.label }}</span>
+            <span class="theme-option__description">{{ theme.description }}</span>
+          </span>
+          <span class="theme-option__badge" *ngIf="isThemeSelected(theme.id)">Ativo</span>
+        </label>
+      </li>
+    </ul>
+  </section>
+
   <section class="profile__achievements" aria-labelledby="achievements-heading">
     <header>
       <h2 id="achievements-heading">Conquistas desbloqueadas</h2>

--- a/src/app/features/profile/pages/profile.page.scss
+++ b/src/app/features/profile/pages/profile.page.scss
@@ -43,7 +43,7 @@
   letter-spacing: 0.08em;
 }
 
-.profile__xp {
+.profile__xp { 
   display: grid;
   gap: 0.75rem;
 }
@@ -56,6 +56,113 @@
 .profile__xp p {
   margin: 0;
   color: var(--hk-text-secondary);
+}
+
+.profile__theme {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.profile__theme > header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.profile__theme > header h2 {
+  margin: 0;
+}
+
+.profile__theme > header p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.theme-options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.theme-options__item {
+  position: relative;
+}
+
+.theme-option__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.theme-option__card {
+  --theme-accent: var(--hk-accent);
+  --theme-soft-accent: rgba(124, 92, 255, 0.22);
+  --theme-preview: linear-gradient(135deg, rgba(124, 92, 255, 0.5), rgba(124, 92, 255, 0.1));
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  cursor: pointer;
+  position: relative;
+  min-height: 100%;
+}
+
+.theme-option__card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.theme-option__card--active {
+  border-color: var(--theme-accent);
+  box-shadow: 0 18px 36px rgba(10, 12, 28, 0.4), 0 0 0 1px var(--theme-accent);
+}
+
+.theme-option__input:focus-visible + .theme-option__card {
+  box-shadow: 0 0 0 1px var(--theme-accent), 0 0 0 4px var(--theme-soft-accent);
+}
+
+.theme-option__card--active .theme-option__title {
+  color: var(--theme-accent);
+}
+
+.theme-option__preview {
+  height: 3rem;
+  border-radius: 0.85rem;
+  background-image: var(--theme-preview);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.theme-option__content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.theme-option__title {
+  font-weight: 600;
+}
+
+.theme-option__description {
+  color: var(--hk-text-muted);
+  font-size: 0.95rem;
+}
+
+.theme-option__badge {
+  justify-self: start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--theme-soft-accent);
+  color: var(--theme-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
 .profile__xp-progress {

--- a/src/app/features/profile/pages/profile.page.ts
+++ b/src/app/features/profile/pages/profile.page.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { DecimalPipe, NgFor } from '@angular/common';
+import { DecimalPipe, NgFor, NgIf } from '@angular/common';
 import { HeroControlState } from '@app/core/state/hero-control.state';
+import { ThemeState, type ThemeId, type ThemeOption } from '@app/core/state/theme.state';
 import type { LootItem, ProfileAchievement } from '@app/core/state/hero-control.models';
 
 @Component({
@@ -9,20 +10,36 @@ import type { LootItem, ProfileAchievement } from '@app/core/state/hero-control.
   templateUrl: './profile.page.html',
   styleUrls: ['./profile.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, DecimalPipe],
+  imports: [NgFor, DecimalPipe, NgIf],
 })
 export class ProfilePageComponent {
   private readonly heroControl = inject(HeroControlState);
+  private readonly themeState = inject(ThemeState);
 
   protected readonly experience = this.heroControl.experience;
   protected readonly experienceProgress = this.heroControl.experienceProgress;
   protected readonly achievements = this.heroControl.achievements;
   protected readonly loot = this.heroControl.loot;
+  protected readonly themes = this.themeState.themes;
+  protected readonly currentTheme = this.themeState.currentTheme;
+
   protected trackAchievement(_: number, achievement: ProfileAchievement): string {
     return achievement.id;
   }
 
   protected trackLoot(_: number, lootItem: LootItem): string {
     return lootItem.id;
+  }
+
+  protected trackTheme(_: number, theme: ThemeOption): ThemeId {
+    return theme.id;
+  }
+
+  protected isThemeSelected(themeId: ThemeId): boolean {
+    return this.currentTheme() === themeId;
+  }
+
+  protected onThemeSelect(themeId: ThemeId): void {
+    this.themeState.setTheme(themeId);
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,7 +13,8 @@ $hero-theme: mat.define-theme((
   @include mat.all-component-themes($hero-theme);
 }
 
-:root {
+:root,
+:root[data-theme='stellar-night'] {
   color-scheme: dark;
   --hk-text-primary: #f3f5ff;
   --hk-text-secondary: rgba(255, 255, 255, 0.88);
@@ -114,6 +115,109 @@ $hero-theme: mat.define-theme((
   --mdc-icon-button-disabled-icon-color: rgba(255, 255, 255, 0.3);
   --mdc-linear-progress-active-indicator-color: var(--hk-accent);
   --mdc-linear-progress-track-color: rgba(124, 92, 255, 0.25);
+}
+
+:root[data-theme='aurora-crest'] {
+  color-scheme: dark;
+  --hk-text-primary: #f1fbff;
+  --hk-text-secondary: rgba(222, 250, 255, 0.92);
+  --hk-text-muted: rgba(203, 235, 242, 0.76);
+  --hk-surface: rgba(6, 33, 44, 0.86);
+  --hk-surface-elevated: rgba(11, 52, 68, 0.92);
+  --hk-border: rgba(173, 255, 252, 0.12);
+  --hk-accent: #1dd3b0;
+  --hk-accent-soft: rgba(29, 211, 176, 0.2);
+  --hk-accent-strong: #0fb9b1;
+  --hk-success: #5ff4d0;
+  --hk-success-soft: rgba(95, 244, 208, 0.18);
+  --hk-warning: #facc15;
+  --hk-danger: #f87171;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #021b27;
+
+  --mat-sys-color-primary: var(--hk-accent);
+  --mat-sys-color-on-primary: #022b27;
+  --mat-sys-color-primary-container: rgba(8, 76, 72, 0.85);
+  --mat-sys-color-on-primary-container: #d2fff4;
+
+  --mat-sys-color-secondary: #38bdf8;
+  --mat-sys-color-on-secondary: #04121d;
+  --mat-sys-color-secondary-container: rgba(10, 58, 92, 0.92);
+  --mat-sys-color-on-secondary-container: #d3f4ff;
+
+  --mat-sys-color-tertiary: #8b5cf6;
+  --mat-sys-color-on-tertiary: #1b083d;
+  --mat-sys-color-tertiary-container: rgba(48, 23, 86, 0.9);
+  --mat-sys-color-on-tertiary-container: #e8ddff;
+
+  --mat-sys-color-error: var(--hk-danger);
+  --mat-sys-color-on-error: #2c0b0b;
+  --mat-sys-color-error-container: rgba(63, 20, 20, 0.9);
+  --mat-sys-color-on-error-container: #fee2e2;
+
+  --mat-sys-color-surface: #021b27;
+  --mat-sys-color-surface-dim: #01131c;
+  --mat-sys-color-surface-bright: #042c3b;
+  --mat-sys-color-surface-container-lowest: #000e15;
+  --mat-sys-color-surface-container-low: rgba(5, 31, 43, 0.86);
+  --mat-sys-color-surface-container: rgba(7, 40, 55, 0.9);
+  --mat-sys-color-surface-container-high: rgba(10, 50, 66, 0.92);
+  --mat-sys-color-surface-container-highest: rgba(13, 66, 80, 0.96);
+
+  --mat-sys-color-on-surface: var(--hk-text-primary);
+  --mat-sys-color-on-surface-variant: rgba(207, 232, 238, 0.72);
+  --mat-sys-color-outline: rgba(173, 255, 252, 0.18);
+  --mat-sys-color-outline-variant: rgba(173, 255, 252, 0.12);
+  --mat-sys-color-inverse-surface: #f1fbff;
+  --mat-sys-color-inverse-on-surface: #0a2531;
+  --mat-sys-color-inverse-primary: #9bf5e5;
+  --mat-sys-color-shadow: rgba(2, 22, 30, 0.55);
+  --mat-sys-color-surface-tint: var(--hk-accent);
+  --mat-sys-elevation-level2: 0 20px 40px rgba(2, 20, 30, 0.45);
+
+  --mat-toolbar-container-background-color: rgba(4, 28, 38, 0.92);
+  --mat-toolbar-container-text-color: var(--hk-text-primary);
+  --mat-toolbar-container-shadow-color: rgba(2, 20, 30, 0.45);
+  --mat-sidenav-container-background-color: #010d14;
+  --mat-sidenav-content-background-color: transparent;
+  --mat-sidenav-container-text-color: var(--hk-text-primary);
+  --mat-list-active-indicator-color: var(--hk-accent);
+  --mat-list-item-label-text-color: var(--hk-text-secondary);
+  --mat-card-background-color: rgba(8, 45, 59, 0.9);
+  --mat-card-title-text-color: var(--hk-text-primary);
+  --mat-card-subtitle-text-color: var(--hk-text-muted);
+  --mat-chip-selected-container-color: var(--hk-accent-soft);
+  --mat-chip-selected-label-text-color: var(--hk-text-primary);
+  --mat-chip-selected-avatar-color: var(--hk-text-primary);
+  --mat-chip-focus-ring-color: rgba(29, 211, 176, 0.35);
+  --mat-select-panel-background-color: rgba(4, 28, 40, 0.98);
+  --mat-select-enabled-trigger-text-color: var(--hk-text-primary);
+  --mat-option-selected-state-label-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-container-color: rgba(4, 25, 34, 0.72);
+  --mdc-filled-text-field-input-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-hover-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-focus-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-active-indicator-color: rgba(29, 211, 176, 0.55);
+  --mdc-filled-text-field-label-text-color: var(--hk-text-muted);
+  --mdc-filled-text-field-hover-label-text-color: var(--hk-text-secondary);
+  --mdc-filled-text-field-focus-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-text-field-outline-color: rgba(29, 211, 176, 0.4);
+  --mdc-outlined-text-field-focus-outline-color: var(--hk-accent);
+  --mdc-outlined-text-field-hover-outline-color: rgba(29, 211, 176, 0.65);
+  --mdc-protected-button-container-color: rgba(29, 211, 176, 0.16);
+  --mdc-protected-button-label-text-color: var(--hk-accent);
+  --mdc-unelevated-button-container-color: var(--hk-accent);
+  --mdc-unelevated-button-label-text-color: #012a2f;
+  --mdc-unelevated-button-disabled-container-color: rgba(255, 255, 255, 0.08);
+  --mdc-unelevated-button-disabled-label-text-color: rgba(255, 255, 255, 0.36);
+  --mdc-outlined-button-outline-color: rgba(29, 211, 176, 0.4);
+  --mdc-outlined-button-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-button-disabled-outline-color: rgba(255, 255, 255, 0.12);
+  --mdc-outlined-button-disabled-label-text-color: rgba(255, 255, 255, 0.3);
+  --mdc-icon-button-icon-color: var(--hk-text-secondary);
+  --mdc-icon-button-disabled-icon-color: rgba(255, 255, 255, 0.3);
+  --mdc-linear-progress-active-indicator-color: var(--hk-accent);
+  --mdc-linear-progress-track-color: rgba(29, 211, 176, 0.25);
 }
 
 body {


### PR DESCRIPTION
## Summary
- add a ThemeState service with tests to manage available UI themes
- expose theme selection controls on the profile page and style the new Aurora Boreal palette
- extend global tokens for the Aurora Crest theme and document the capability in the README

## Testing
- npm test -- --watch=false --progress=false *(fails: Chrome browser binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de889b677883338440fcb9f0ed755e