### PR TITLE
feat: allow creating features from catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Os testes cobrem o shell principal e regras de negócio dos serviços de estado 
 ### Feature Explorer (`/features`)
 - `FeatureExplorerState` agrega dados do quadro e expõe view models para catálogo e detalhe de features.
 - Signals e `computed` sincronizam cards e listas sem lógica adicional nos templates.
+- Catálogo conta com botão **Nova feature** que abre modal validando tema, missão e recompensa antes de registrar no `BoardState`.
 
 ### Sprints (`/sprints`)
 - Aproveita `BoardState.sprintOverviews` para listar objetivos, datas e status das histórias de cada sprint.

--- a/src/app/features/board/state/board-state.service.ts
+++ b/src/app/features/board/state/board-state.service.ts
@@ -4,6 +4,7 @@ import type {
   BoardColumnViewModel,
   BoardStatus,
   BoardStatusWithCapacity,
+  CreateFeaturePayload,
   CreateStoryPayload,
   Feature,
   Mission,
@@ -52,6 +53,21 @@ export class BoardState {
       mission: 'Criar sistema de desbloqueio de cosméticos e efeitos.',
     },
   ]);
+
+  createFeature(payload: CreateFeaturePayload): void {
+    const featureId = `feat-${crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
+
+    const newFeature: Feature = {
+      id: featureId,
+      title: payload.title.trim(),
+      theme: payload.theme.trim(),
+      mission: payload.mission.trim(),
+      xpReward: Math.max(0, Math.round(payload.xpReward)),
+      progress: 0,
+    };
+
+    this._features.update((current) => [...current, newFeature]);
+  }
 
   private readonly _missions = signal<Mission[]>([
     {

--- a/src/app/features/board/state/board.models.ts
+++ b/src/app/features/board/state/board.models.ts
@@ -90,6 +90,13 @@ export interface Feature {
   readonly mission: string;
 }
 
+export interface CreateFeaturePayload {
+  readonly title: string;
+  readonly theme: string;
+  readonly mission: string;
+  readonly xpReward: number;
+}
+
 export interface BoardCardViewModel {
   readonly id: string;
   readonly title: string;

--- a/src/app/features/feature-explorer/components/create-feature-dialog/create-feature-dialog.component.html
+++ b/src/app/features/feature-explorer/components/create-feature-dialog/create-feature-dialog.component.html
@@ -1,0 +1,41 @@
+<h2 mat-dialog-title>Nova feature</h2>
+<form class="create-feature" [formGroup]="featureForm" (ngSubmit)="onSubmit()">
+  <mat-dialog-content>
+    <p class="create-feature__description">
+      Preencha a ficha da missão para adicionar uma nova feature ao mapa da guilda.
+    </p>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Nome da feature</mat-label>
+      <input matInput formControlName="title" cdkFocusInitial maxlength="80" required />
+      <mat-hint align="end">{{ featureForm.get('title')?.value?.length ?? 0 }}/80</mat-hint>
+      <mat-error *ngIf="featureForm.get('title')?.hasError('required')">Informe um nome.</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Tema</mat-label>
+      <input matInput formControlName="theme" maxlength="100" required />
+      <mat-hint align="end">{{ featureForm.get('theme')?.value?.length ?? 0 }}/100</mat-hint>
+      <mat-error *ngIf="featureForm.get('theme')?.hasError('required')">Descreva o tema.</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Missão</mat-label>
+      <textarea matInput formControlName="mission" rows="3" maxlength="200" required></textarea>
+      <mat-hint align="end">{{ featureForm.get('mission')?.value?.length ?? 0 }}/200</mat-hint>
+      <mat-error *ngIf="featureForm.get('mission')?.hasError('required')">Explique a missão.</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="fill">
+      <mat-label>Recompensa de XP</mat-label>
+      <input matInput type="number" min="0" formControlName="xpReward" required />
+      <mat-error *ngIf="featureForm.get('xpReward')?.hasError('required')">Informe o XP previsto.</mat-error>
+      <mat-error *ngIf="featureForm.get('xpReward')?.hasError('min')">Use um valor positivo.</mat-error>
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button type="button" mat-stroked-button (click)="onCancel()">Cancelar</button>
+    <button type="submit" mat-flat-button color="primary">Adicionar feature</button>
+  </mat-dialog-actions>
+</form>

--- a/src/app/features/feature-explorer/components/create-feature-dialog/create-feature-dialog.component.scss
+++ b/src/app/features/feature-explorer/components/create-feature-dialog/create-feature-dialog.component.scss
@@ -1,0 +1,29 @@
+.create-feature {
+  display: grid;
+  gap: 1.5rem;
+  color: var(--hk-text-primary);
+}
+
+.create-feature__description {
+  margin: 0 0 1rem;
+  color: var(--hk-text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+mat-dialog-actions {
+  padding: 0 1.5rem 1.5rem;
+}
+
+button[mat-flat-button] {
+  font-weight: 600;
+}
+
+button[mat-stroked-button] {
+  border-color: rgba(124, 92, 255, 0.45);
+  color: var(--hk-text-primary);
+}

--- a/src/app/features/feature-explorer/components/create-feature-dialog/create-feature-dialog.component.ts
+++ b/src/app/features/feature-explorer/components/create-feature-dialog/create-feature-dialog.component.ts
@@ -1,0 +1,64 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NgIf } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+export interface CreateFeatureDialogResult {
+  readonly title: string;
+  readonly theme: string;
+  readonly mission: string;
+  readonly xpReward: number;
+}
+
+@Component({
+  selector: 'hk-create-feature-dialog',
+  standalone: true,
+  templateUrl: './create-feature-dialog.component.html',
+  styleUrls: ['./create-feature-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatDialogModule, MatButtonModule, MatFormFieldModule, MatInputModule, ReactiveFormsModule, NgIf],
+})
+export class CreateFeatureDialogComponent {
+  private readonly dialogRef = inject<MatDialogRef<CreateFeatureDialogComponent, CreateFeatureDialogResult>>(MatDialogRef);
+  private readonly formBuilder = inject(FormBuilder);
+
+  protected readonly featureForm = this.formBuilder.group({
+    title: this.formBuilder.nonNullable.control('', {
+      validators: [Validators.required, Validators.maxLength(80)],
+    }),
+    theme: this.formBuilder.nonNullable.control('', {
+      validators: [Validators.required, Validators.maxLength(100)],
+    }),
+    mission: this.formBuilder.nonNullable.control('', {
+      validators: [Validators.required, Validators.maxLength(200)],
+    }),
+    xpReward: this.formBuilder.control<number | null>(250, {
+      validators: [Validators.required, Validators.min(0)],
+    }),
+  });
+
+  protected onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  protected onSubmit(): void {
+    if (this.featureForm.invalid) {
+      this.featureForm.markAllAsTouched();
+      return;
+    }
+
+    const rawValue = this.featureForm.getRawValue();
+
+    const result: CreateFeatureDialogResult = {
+      title: rawValue.title.trim(),
+      theme: rawValue.theme.trim(),
+      mission: rawValue.mission.trim(),
+      xpReward: Number(rawValue.xpReward ?? 0),
+    };
+
+    this.dialogRef.close(result);
+  }
+}

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.html
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.html
@@ -1,9 +1,15 @@
 <section class="catalog" aria-labelledby="feature-catalog-title">
   <header class="catalog__header">
-    <h1 id="feature-catalog-title">Explorar features e histórias</h1>
-    <p>
-      Conheça as missões épicas em andamento. Cada feature reúne histórias que impulsionam a jornada da guilda.
-    </p>
+    <div class="catalog__heading">
+      <h1 id="feature-catalog-title">Explorar features e histórias</h1>
+      <p>
+        Conheça as missões épicas em andamento. Cada feature reúne histórias que impulsionam a jornada da guilda.
+      </p>
+    </div>
+    <button type="button" mat-flat-button color="primary" class="catalog__cta" (click)="openCreateFeatureDialog()">
+      <mat-icon>add</mat-icon>
+      Nova feature
+    </button>
   </header>
 
   <ng-container *ngIf="featureCards().length > 0; else emptyState">

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.scss
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.scss
@@ -5,20 +5,39 @@
 }
 
 .catalog__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.catalog__heading {
   display: grid;
   gap: 0.75rem;
   max-width: 60ch;
 }
 
-.catalog__header > h1 {
+.catalog__heading > h1 {
   margin: 0;
   font-size: clamp(1.75rem, 3vw, 2.4rem);
   color: var(--hk-text-primary);
 }
 
-.catalog__header > p {
+.catalog__heading > p {
   margin: 0;
   font-size: 1.05rem;
+}
+
+.catalog__cta {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-inline: 1.25rem;
+  font-weight: 600;
+  border-radius: 999px;
+  box-shadow: 0 1rem 2.25rem rgba(124, 92, 255, 0.28);
 }
 
 .catalog__grid {

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.ts
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.ts
@@ -1,8 +1,16 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 import { RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
 import type { FeatureOverviewCardViewModel } from '../state/feature-explorer.models';
 import { FeatureExplorerState } from '../state/feature-explorer.state';
+import {
+  CreateFeatureDialogComponent,
+  type CreateFeatureDialogResult,
+} from '../components/create-feature-dialog/create-feature-dialog.component';
 
 @Component({
   selector: 'hk-feature-catalog-page',
@@ -10,14 +18,36 @@ import { FeatureExplorerState } from '../state/feature-explorer.state';
   templateUrl: './feature-catalog.page.html',
   styleUrls: ['./feature-catalog.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIf, NgFor, RouterLink],
+  imports: [NgIf, NgFor, RouterLink, MatButtonModule, MatIconModule],
 })
 export class FeatureCatalogPage {
   private readonly featureExplorerState = inject(FeatureExplorerState);
+  private readonly dialog = inject(MatDialog);
 
   protected readonly featureCards = this.featureExplorerState.featureCards;
 
   protected trackById(_: number, card: FeatureOverviewCardViewModel): string {
     return card.id;
+  }
+
+  protected async openCreateFeatureDialog(): Promise<void> {
+    const dialogRef = this.dialog.open<CreateFeatureDialogComponent, void, CreateFeatureDialogResult>(
+      CreateFeatureDialogComponent,
+      {
+        width: '480px',
+      },
+    );
+
+    const result = await firstValueFrom(dialogRef.afterClosed());
+    if (!result) {
+      return;
+    }
+
+    this.featureExplorerState.createFeature({
+      title: result.title,
+      theme: result.theme,
+      mission: result.mission,
+      xpReward: result.xpReward,
+    });
   }
 }

--- a/src/app/features/feature-explorer/state/feature-explorer.state.ts
+++ b/src/app/features/feature-explorer/state/feature-explorer.state.ts
@@ -7,6 +7,7 @@ import type {
   FeatureOverviewCardViewModel,
   FeatureStoryCardViewModel,
 } from './feature-explorer.models';
+import type { CreateFeaturePayload } from '@features/board/state/board.models';
 
 const PRIORITY_METADATA: Record<Priority, { readonly label: string; readonly color: string }> = {
   low: { label: 'Baixo', color: '#4ade80' },
@@ -73,6 +74,10 @@ export class FeatureExplorerState {
 
   getFeatureDetail(featureId: string): FeatureDetailViewModel | undefined {
     return this.featureDetailsMap().get(featureId);
+  }
+
+  createFeature(payload: CreateFeaturePayload): void {
+    this.boardState.createFeature(payload);
   }
 
   private toFeatureCard(feature: Feature, storyCount: number): FeatureOverviewCardViewModel {


### PR DESCRIPTION
## Summary
- add a "Nova feature" call-to-action to the feature catalog header
- implement a create-feature dialog with form validation that persists to the board state
- document the new flow in the project README

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de93cfbc5483339b3969b221e10028