### PR TITLE
fix: restore material symbol icons

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter } from '@angular/router';
+import { MAT_ICON_DEFAULT_OPTIONS, MatIconDefaultOptions } from '@angular/material/icon';
 
 import { routes } from './app.routes';
 
@@ -9,5 +10,11 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideAnimationsAsync(),
+    {
+      provide: MAT_ICON_DEFAULT_OPTIONS,
+      useValue: {
+        fontSet: 'material-symbols-rounded',
+      } satisfies MatIconDefaultOptions,
+    },
   ],
 };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,23 @@ $hero-theme: mat.define-theme((
   @include mat.all-component-themes($hero-theme);
 }
 
+.material-symbols-rounded {
+  font-family: 'Material Symbols Rounded', sans-serif;
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  display: inline-block;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+  font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
 :root,
 :root[data-theme='stellar-night'] {
   color-scheme: dark;


### PR DESCRIPTION
## Summary
- configure the global MatIcon default options to use the Material Symbols Rounded font ligatures
- add explicit Material Symbols Rounded font styles so ligatures render instead of raw icon names

## Testing
- CI=1 npm test -- --watch=false *(fails: Chrome browser binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de97037c14833399fc60912806d5ca