### PR TITLE
feat: enable full customization of board stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Os testes cobrem o shell principal e regras de negócio dos serviços de estado 
 - Métricas destacam XP acumulado, nível e throughput semanal diretamente no header.
 
 ### Personalização do quadro (`/quadro/personalizar`)
-- Página `BoardCustomizerPageComponent` manipula `BoardConfigState`, permitindo ativar/pausar etapas e ajustar limites.
+- Página `BoardCustomizerPageComponent` manipula `BoardConfigState`, permitindo ativar/pausar etapas, renomear títulos e subtítulos e escolher o ícone que representa cada fase.
+- Etapas podem ser reordenadas para refletir o fluxo atual com comandos acessíveis (setas) e o resultado é persistido no `order` das colunas.
 - Atualizações refletem imediatamente no quadro principal graças ao estado compartilhado.
 
 ### Feature Explorer (`/features`)

--- a/src/app/features/board-customizer/pages/board-customizer.page.html
+++ b/src/app/features/board-customizer/pages/board-customizer.page.html
@@ -9,22 +9,78 @@
   <section class="board-customizer__statuses" aria-labelledby="status-list-heading">
     <header>
       <h2 id="status-list-heading">Etapas disponíveis</h2>
-      <p>Ative apenas os estágios relevantes para o ciclo atual.</p>
+      <p>Personalize a identidade de cada etapa e organize o fluxo de trabalho na ordem ideal.</p>
     </header>
     <ul>
-      <li *ngFor="let status of statuses(); trackBy: trackStatus">
-        <label class="status-toggle">
-          <input
-            type="checkbox"
-            [checked]="status.isActive"
-            (change)="onStatusToggle(status.id, $event)"
-            [attr.aria-label]="'Alternar etapa ' + status.label"
-          />
-          <span class="status-toggle__body">
-            <span class="status-toggle__label">{{ status.label }}</span>
-            <span class="status-toggle__description">{{ status.description }}</span>
-          </span>
-        </label>
+      <li *ngFor="let status of statuses(); let index = index; let isLast = last; trackBy: trackStatus" class="status-card">
+        <header class="status-card__header">
+          <div class="status-card__reorder" aria-label="Ordenar etapa">
+            <button
+              type="button"
+              (click)="onMoveStatus(status.id, 'up')"
+              [disabled]="index === 0"
+              [attr.aria-label]="'Mover ' + status.name + ' para cima'"
+            >
+              <span class="material-symbols-rounded" aria-hidden="true">arrow_upward</span>
+            </button>
+            <button
+              type="button"
+              (click)="onMoveStatus(status.id, 'down')"
+              [disabled]="isLast"
+              [attr.aria-label]="'Mover ' + status.name + ' para baixo'"
+            >
+              <span class="material-symbols-rounded" aria-hidden="true">arrow_downward</span>
+            </button>
+          </div>
+          <div class="status-card__identity">
+            <span class="material-symbols-rounded status-card__icon" aria-hidden="true">{{ status.icon }}</span>
+            <span class="status-card__order">Etapa {{ index + 1 }}</span>
+          </div>
+          <label class="status-card__toggle">
+            <input
+              type="checkbox"
+              [checked]="status.isActive"
+              (change)="onStatusToggle(status.id, $event)"
+              [attr.aria-label]="'Alternar etapa ' + status.name"
+            />
+            <span>Ativa</span>
+          </label>
+        </header>
+        <div class="status-card__form">
+          <label class="status-field">
+            <span class="status-field__label">Título</span>
+            <input
+              type="text"
+              [value]="status.name"
+              (input)="onStatusTitleChange(status.id, $event)"
+              autocomplete="off"
+              placeholder="Nome da etapa"
+            />
+          </label>
+          <label class="status-field">
+            <span class="status-field__label">Subtítulo</span>
+            <textarea
+              rows="2"
+              [value]="status.description"
+              (input)="onStatusSubtitleChange(status.id, $event)"
+              placeholder="Descrição rápida da etapa"
+            ></textarea>
+          </label>
+          <label class="status-field">
+            <span class="status-field__label">Ícone</span>
+            <div class="status-field__icon-select">
+              <span class="material-symbols-rounded" aria-hidden="true">{{ status.icon }}</span>
+              <select [value]="status.icon" (change)="onStatusIconChange(status.id, $event)">
+                <option *ngFor="let option of iconOptions" [value]="option.value">
+                  {{ option.label }}
+                </option>
+                <option *ngIf="!hasIconOption(status.icon)" [value]="status.icon">
+                  {{ status.icon }}
+                </option>
+              </select>
+            </div>
+          </label>
+        </div>
       </li>
     </ul>
   </section>
@@ -44,7 +100,7 @@
           placeholder="Ex.: Em validação"
           autocomplete="off"
           [value]="newStatusName()"
-          (input)="onStatusNameInput($event)"
+          (input)="onNewStatusNameInput($event)"
         />
         <button type="submit" [disabled]="!canCreateStatus()">Adicionar</button>
       </div>

--- a/src/app/features/board-customizer/pages/board-customizer.page.scss
+++ b/src/app/features/board-customizer/pages/board-customizer.page.scss
@@ -53,46 +53,157 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
-.status-toggle {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.9rem;
-  padding: 1rem;
+.status-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
   border-radius: 1.25rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.05);
   transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.status-card:hover,
+.status-card:focus-within {
+  border-color: rgba(124, 92, 255, 0.45);
+  background: rgba(124, 92, 255, 0.12);
+}
+
+.status-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.status-card__reorder {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.status-card__reorder button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(17, 24, 39, 0.7);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.status-card__reorder button:hover:not(:disabled),
+.status-card__reorder button:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(124, 92, 255, 0.6);
+  background: rgba(124, 92, 255, 0.25);
+}
+
+.status-card__reorder button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.status-card__identity {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: var(--hk-text-muted);
+}
+
+.status-card__order {
+  font-size: 0.9rem;
+}
+
+.status-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.85rem;
+  background: rgba(124, 92, 255, 0.2);
+  color: #e2e8f0;
+  font-size: 1.6rem;
+}
+
+.status-card__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--hk-text-muted);
   cursor: pointer;
 }
 
-.status-toggle:hover,
-.status-toggle:focus-within {
-  border-color: rgba(124, 92, 255, 0.45);
-  background: rgba(124, 92, 255, 0.16);
-}
-
-.status-toggle input {
-  margin-top: 0.2rem;
+.status-card__toggle input {
   width: 1.1rem;
   height: 1.1rem;
   accent-color: #7c5cff;
 }
 
-.status-toggle__body {
+.status-card__form {
   display: grid;
-  gap: 0.3rem;
+  gap: 1rem;
 }
 
-.status-toggle__label {
+.status-field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.status-field__label {
   font-weight: 600;
 }
 
-.status-toggle__description {
-  color: var(--hk-text-muted);
-  font-size: 0.95rem;
+.status-field input,
+.status-field textarea,
+.status-field select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(8, 8, 18, 0.5);
+  color: inherit;
+  font: inherit;
+  resize: none;
+}
+
+.status-field textarea {
+  min-height: 3.5rem;
+}
+
+.status-field input:focus-visible,
+.status-field textarea:focus-visible,
+.status-field select:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.status-field__icon-select {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status-field__icon-select span.material-symbols-rounded {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background: rgba(124, 92, 255, 0.2);
+  color: #f8fafc;
 }
 
 .status-form__label {
@@ -150,6 +261,15 @@
 @media (max-width: 720px) {
   .board-customizer {
     padding: clamp(1rem, 6vw, 2rem);
+  }
+
+  .status-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .status-card__reorder {
+    order: 2;
   }
 
   .status-form__controls {

--- a/src/app/features/board-customizer/pages/board-customizer.page.ts
+++ b/src/app/features/board-customizer/pages/board-customizer.page.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 import { BoardConfigState } from '@features/board/state/board-config.state';
-import type { BoardStatusToggleOption } from '@features/board/state/board-config.state';
+import type { BoardStatusEditorOption } from '@features/board/state/board-config.state';
 
 @Component({
   selector: 'hk-board-customizer-page',
@@ -17,8 +17,20 @@ export class BoardCustomizerPageComponent {
   protected readonly statuses = this.boardConfig.statusOptions;
   protected readonly newStatusName = this.boardConfig.newStatusName;
   protected readonly canCreateStatus = this.boardConfig.canCreateStatus;
+  protected readonly iconOptions: readonly IconOption[] = [
+    { value: 'lightbulb', label: 'Ideação' },
+    { value: 'rocket_launch', label: 'Preparação' },
+    { value: 'smart_toy', label: 'Construção' },
+    { value: 'stadia_controller', label: 'Teste / Playtest' },
+    { value: 'rocket', label: 'Deploy' },
+    { value: 'emoji_events', label: 'Conquista' },
+    { value: 'ac_unit', label: 'Icebox' },
+    { value: 'report', label: 'Bloqueio' },
+    { value: 'flag', label: 'Checkpoint' },
+    { value: 'auto_awesome', label: 'Iteração' },
+  ];
 
-  protected trackStatus(_: number, status: BoardStatusToggleOption): string {
+  protected trackStatus(_: number, status: BoardStatusEditorOption): string {
     return status.id;
   }
 
@@ -32,7 +44,7 @@ export class BoardCustomizerPageComponent {
     this.boardConfig.toggleStatus(statusId, target.checked);
   }
 
-  protected onStatusNameInput(event: Event): void {
+  protected onNewStatusNameInput(event: Event): void {
     const target = event.target;
 
     if (!(target instanceof HTMLInputElement)) {
@@ -46,4 +58,47 @@ export class BoardCustomizerPageComponent {
     event.preventDefault();
     this.boardConfig.addCustomStatus();
   }
+
+  protected onStatusTitleChange(statusId: string, event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    this.boardConfig.updateStatusName(statusId, target.value);
+  }
+
+  protected onStatusSubtitleChange(statusId: string, event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement)) {
+      return;
+    }
+
+    this.boardConfig.updateStatusDescription(statusId, target.value);
+  }
+
+  protected onStatusIconChange(statusId: string, event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    this.boardConfig.updateStatusIcon(statusId, target.value);
+  }
+
+  protected onMoveStatus(statusId: string, direction: 'up' | 'down'): void {
+    this.boardConfig.moveStatus(statusId, direction);
+  }
+
+  protected hasIconOption(icon: string): boolean {
+    return this.iconOptions.some((option) => option.value === icon);
+  }
+}
+
+interface IconOption {
+  readonly value: string;
+  readonly label: string;
 }

--- a/src/app/features/board/state/board-config.state.spec.ts
+++ b/src/app/features/board/state/board-config.state.spec.ts
@@ -13,7 +13,10 @@ describe('BoardConfigState', () => {
     const options = state.statusOptions();
 
     expect(options.length).toBe(state.statuses().length);
-    expect(options.every((option) => typeof option.label === 'string')).toBeTrue();
+    expect(options.every((option) => typeof option.name === 'string')).toBeTrue();
+    expect(options.every((option) => typeof option.icon === 'string')).toBeTrue();
+    const orders = options.map((option) => option.order);
+    expect([...orders].sort((a, b) => a - b)).toEqual(orders);
   });
 
   it('should add a custom status and propagate transitions', () => {
@@ -50,5 +53,46 @@ describe('BoardConfigState', () => {
     state.toggleStatus(target.id, !target.isActive);
 
     expect(state.statuses()[0].isActive).toBe(!target.isActive);
+  });
+
+  it('should update the title and short label of a status', () => {
+    const target = state.statuses()[0];
+
+    state.updateStatusName(target.id, 'Nova Etapa Lendária');
+
+    const updated = state.statuses()[0];
+    expect(updated.name).toBe('Nova Etapa Lendária');
+    expect(updated.shortLabel).toBe('Nova Etapa…');
+  });
+
+  it('should update the description of a status', () => {
+    const target = state.statuses()[1];
+
+    state.updateStatusDescription(target.id, '  Ajuste fino com toda a guilda reunida   ');
+
+    expect(state.statuses()[1].description).toBe('Ajuste fino com toda a guilda reunida');
+  });
+
+  it('should update the icon of a status and fallback when empty', () => {
+    const target = state.statuses()[2];
+
+    state.updateStatusIcon(target.id, 'auto_awesome');
+    expect(state.statuses()[2].icon).toBe('auto_awesome');
+
+    state.updateStatusIcon(target.id, '  ');
+    expect(state.statuses()[2].icon).toBe('flag');
+  });
+
+  it('should move statuses up and down updating their order', () => {
+    const before = state.statusOptions().map((option) => option.id);
+    const targetId = before[1];
+
+    state.moveStatus(targetId, 'up');
+    const afterUp = state.statusOptions().map((option) => option.id);
+    expect(afterUp[0]).toBe(targetId);
+
+    state.moveStatus(targetId, 'down');
+    const afterDown = state.statusOptions().map((option) => option.id);
+    expect(afterDown[1]).toBe(targetId);
   });
 });


### PR DESCRIPTION
## Summary
- allow customizing each board stage with editable title, subtitle, icon and ordering controls
- extend BoardConfigState with update helpers and tests covering renaming, icon changes and reordering
- refresh the board customization UI styles and README documentation to reflect the richer workflow controls

## Testing
- npm test -- --watch=false *(fails: missing Chrome binary in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9e02accc833384c8757b33977800