### PR TITLE
feat: enable drag and drop ordering for board statuses

### DIFF
--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.html
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.html
@@ -1,0 +1,67 @@
+<section class="status-editor-modal" (keydown.escape)="onCancel()">
+  <div class="status-editor-modal__backdrop" (click)="onCancel()" aria-hidden="true"></div>
+  <div
+    class="status-editor-modal__panel"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-labelledby]="'status-editor-title-' + status().id"
+  >
+    <form class="status-editor-modal__form" [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+      <header class="status-editor-modal__header">
+        <div class="status-editor-modal__symbol" aria-hidden="true">
+          <span class="material-symbols-rounded">{{ status().icon }}</span>
+        </div>
+        <div>
+          <h2 [id]="'status-editor-title-' + status().id">Editar etapa</h2>
+          <p>Atualize o nome, a descrição e o ícone exibidos na jornada do quadro.</p>
+        </div>
+        <button
+          type="button"
+          class="status-editor-modal__close"
+          (click)="onCancel()"
+          aria-label="Fechar editor"
+        >
+          <span class="material-symbols-rounded" aria-hidden="true">close</span>
+        </button>
+      </header>
+
+      <div class="status-editor-modal__fields">
+        <label class="status-editor-modal__field">
+          <span>Nome</span>
+          <input type="text" formControlName="name" autocomplete="off" required />
+          <small *ngIf="form.controls.name.invalid && form.controls.name.touched">
+            Informe um nome com pelo menos 3 caracteres.
+          </small>
+        </label>
+
+        <label class="status-editor-modal__field">
+          <span>Descrição</span>
+          <textarea
+            rows="3"
+            formControlName="description"
+            placeholder="Contexto exibido no quadro"
+          ></textarea>
+        </label>
+
+        <label class="status-editor-modal__field">
+          <span>Ícone</span>
+          <div class="status-editor-modal__icon-select">
+            <span class="material-symbols-rounded" aria-hidden="true">
+              {{ form.controls.icon.value || status().icon }}
+            </span>
+            <select formControlName="icon">
+              <option *ngFor="let option of iconOptionsWithFallback()" [value]="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </div>
+        </label>
+      </div>
+
+      <footer class="status-editor-modal__footer">
+        <button type="button" class="status-editor-modal__secondary" (click)="onCancel()">Cancelar</button>
+        <button type="submit" class="status-editor-modal__primary">Salvar alterações</button>
+      </footer>
+    </form>
+  </div>
+</section>

--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.scss
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.scss
@@ -1,0 +1,210 @@
+:host {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+}
+
+.status-editor-modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+}
+
+.status-editor-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(8, 10, 24, 0.7);
+  backdrop-filter: blur(6px);
+  pointer-events: auto;
+}
+
+.status-editor-modal__panel {
+  position: relative;
+  width: min(520px, calc(100vw - 2.5rem));
+  border-radius: 1.5rem;
+  background: rgba(17, 19, 35, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 32px 72px rgba(10, 12, 28, 0.55);
+  pointer-events: auto;
+}
+
+.status-editor-modal__form {
+  display: grid;
+  gap: 1.75rem;
+  padding: clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.status-editor-modal__header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  align-items: start;
+}
+
+.status-editor-modal__symbol {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  background: rgba(124, 92, 255, 0.25);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #ede9fe;
+  font-size: 1.9rem;
+}
+
+.status-editor-modal__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.status-editor-modal__header p {
+  margin: 0.35rem 0 0;
+  color: var(--hk-text-muted);
+}
+
+.status-editor-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 23, 42, 0.7);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.status-editor-modal__close:hover,
+.status-editor-modal__close:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(124, 92, 255, 0.6);
+  background: rgba(124, 92, 255, 0.25);
+}
+
+.status-editor-modal__fields {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.status-editor-modal__field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.status-editor-modal__field span {
+  font-weight: 600;
+}
+
+.status-editor-modal__field input,
+.status-editor-modal__field textarea,
+.status-editor-modal__field select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(8, 8, 18, 0.55);
+  color: inherit;
+  font: inherit;
+  resize: vertical;
+}
+
+.status-editor-modal__field textarea {
+  min-height: 5.5rem;
+}
+
+.status-editor-modal__field input:focus-visible,
+.status-editor-modal__field textarea:focus-visible,
+.status-editor-modal__field select:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.status-editor-modal__field small {
+  color: #fda4af;
+  font-size: 0.8rem;
+}
+
+.status-editor-modal__icon-select {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status-editor-modal__icon-select span.material-symbols-rounded {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.8rem;
+  background: rgba(124, 92, 255, 0.2);
+  color: #f8fafc;
+  font-size: 1.7rem;
+}
+
+.status-editor-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.status-editor-modal__secondary,
+.status-editor-modal__primary {
+  padding: 0.75rem 1.4rem;
+  border-radius: 0.9rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.status-editor-modal__secondary {
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+}
+
+.status-editor-modal__secondary:hover,
+.status-editor-modal__secondary:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.status-editor-modal__primary {
+  background: linear-gradient(135deg, #7c5cff 0%, #4f46e5 100%);
+  color: #ffffff;
+}
+
+.status-editor-modal__primary:hover,
+.status-editor-modal__primary:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+@media (max-width: 540px) {
+  .status-editor-modal__panel {
+    width: calc(100vw - 1.5rem);
+  }
+
+  .status-editor-modal__header {
+    grid-template-columns: 1fr auto;
+  }
+
+  .status-editor-modal__symbol {
+    display: none;
+  }
+
+  .status-editor-modal__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .status-editor-modal__secondary,
+  .status-editor-modal__primary {
+    width: 100%;
+  }
+}

--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.ts
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.ts
@@ -1,0 +1,94 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import type { BoardStatusEditorOption } from '@features/board/state/board-config.state';
+
+interface IconOption {
+  readonly value: string;
+  readonly label: string;
+}
+
+export type StatusEditorFormValue = Readonly<{
+  name: string;
+  description: string;
+  icon: string;
+}>;
+
+@Component({
+  selector: 'hk-status-editor-modal',
+  standalone: true,
+  templateUrl: './status-editor-modal.component.html',
+  styleUrls: ['./status-editor-modal.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgFor, NgIf, ReactiveFormsModule],
+})
+export class StatusEditorModalComponent {
+  readonly status = input.required<BoardStatusEditorOption>();
+  readonly iconOptions = input.required<readonly IconOption[]>();
+
+  readonly dismissed = output<void>();
+  readonly submitted = output<StatusEditorFormValue>();
+
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+
+  protected readonly form = this.formBuilder.group({
+    name: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    description: this.formBuilder.control(''),
+    icon: this.formBuilder.control('', Validators.required),
+  });
+
+  protected readonly iconOptionsWithFallback = computed(() => {
+    const options = this.iconOptions();
+    const currentIcon = this.status().icon;
+
+    if (options.some((option) => option.value === currentIcon)) {
+      return options;
+    }
+
+    return [...options, { value: currentIcon, label: currentIcon } satisfies IconOption];
+  });
+
+  private readonly syncFormEffect = effect(
+    () => {
+      const current = this.status();
+      this.form.reset({
+        name: current.name,
+        description: current.description,
+        icon: current.icon,
+      });
+    },
+    { allowSignalWrites: true },
+  );
+
+  protected onCancel(): void {
+    this.dismissed.emit();
+  }
+
+  protected onSubmit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const value = this.form.getRawValue();
+    const payload: StatusEditorFormValue = {
+      name: value.name.trim(),
+      description: value.description?.trim() ?? '',
+      icon: value.icon.trim(),
+    };
+
+    this.submitted.emit(payload);
+  }
+}

--- a/src/app/features/board-customizer/pages/board-customizer.page.html
+++ b/src/app/features/board-customizer/pages/board-customizer.page.html
@@ -11,75 +11,71 @@
       <h2 id="status-list-heading">Etapas disponíveis</h2>
       <p>Personalize a identidade de cada etapa e organize o fluxo de trabalho na ordem ideal.</p>
     </header>
-    <ul>
-      <li *ngFor="let status of statuses(); let index = index; let isLast = last; trackBy: trackStatus" class="status-card">
-        <header class="status-card__header">
-          <div class="status-card__reorder" aria-label="Ordenar etapa">
+    <ul
+      class="status-list"
+      cdkDropList
+      [cdkDropListData]="statuses()"
+      (cdkDropListDropped)="onStatusDrop($event)"
+      aria-describedby="status-list-heading"
+    >
+      <li
+        *ngFor="let status of statuses(); let index = index; trackBy: trackStatus"
+        class="status-item"
+        cdkDrag
+        cdkDragLockAxis="y"
+        [cdkDragData]="status"
+      >
+        <div class="status-item__main">
+          <span class="material-symbols-rounded status-item__icon" aria-hidden="true">{{ status.icon }}</span>
+          <div class="status-item__info">
+            <p class="status-item__title">{{ status.name }}</p>
+            <p class="status-item__subtitle">{{ status.description || 'Sem descrição cadastrada.' }}</p>
+          </div>
+        </div>
+
+        <div class="status-item__meta">
+          <div class="status-item__snacks" role="list" aria-label="Resumo da etapa">
+            <span class="status-item__snack" role="listitem">Etapa {{ index + 1 }}</span>
+            <span
+              class="status-item__snack"
+              [class.status-item__snack--inactive]="!status.isActive"
+              role="listitem"
+            >
+              {{ status.isActive ? 'Ativa' : 'Inativa' }}
+            </span>
+          </div>
+
+          <div class="status-item__actions" aria-label="Ações da etapa">
             <button
               type="button"
-              (click)="onMoveStatus(status.id, 'up')"
-              [disabled]="index === 0"
-              [attr.aria-label]="'Mover ' + status.name + ' para cima'"
+              class="status-item__drag-handle"
+              cdkDragHandle
+              [attr.aria-label]="'Reordenar etapa ' + status.name"
+              title="Arraste para reordenar"
             >
-              <span class="material-symbols-rounded" aria-hidden="true">arrow_upward</span>
+              <span class="material-symbols-rounded" aria-hidden="true">drag_indicator</span>
             </button>
+
+            <label class="status-item__toggle">
+              <input
+                type="checkbox"
+                [checked]="status.isActive"
+                (change)="onStatusToggle(status.id, $event)"
+                [attr.aria-label]="'Alternar etapa ' + status.name"
+              />
+              <span>{{ status.isActive ? 'Ativa' : 'Inativa' }}</span>
+            </label>
+
             <button
               type="button"
-              (click)="onMoveStatus(status.id, 'down')"
-              [disabled]="isLast"
-              [attr.aria-label]="'Mover ' + status.name + ' para baixo'"
+              class="status-item__edit"
+              (click)="openStatusEditor(status.id)"
+              [attr.aria-label]="'Editar etapa ' + status.name"
             >
-              <span class="material-symbols-rounded" aria-hidden="true">arrow_downward</span>
+              <span class="material-symbols-rounded" aria-hidden="true">edit</span>
+              Editar
             </button>
           </div>
-          <div class="status-card__identity">
-            <span class="material-symbols-rounded status-card__icon" aria-hidden="true">{{ status.icon }}</span>
-            <span class="status-card__order">Etapa {{ index + 1 }}</span>
-          </div>
-          <label class="status-card__toggle">
-            <input
-              type="checkbox"
-              [checked]="status.isActive"
-              (change)="onStatusToggle(status.id, $event)"
-              [attr.aria-label]="'Alternar etapa ' + status.name"
-            />
-            <span>Ativa</span>
-          </label>
-        </header>
-        <div class="status-card__form">
-          <label class="status-field">
-            <span class="status-field__label">Título</span>
-            <input
-              type="text"
-              [value]="status.name"
-              (input)="onStatusTitleChange(status.id, $event)"
-              autocomplete="off"
-              placeholder="Nome da etapa"
-            />
-          </label>
-          <label class="status-field">
-            <span class="status-field__label">Subtítulo</span>
-            <textarea
-              rows="2"
-              [value]="status.description"
-              (input)="onStatusSubtitleChange(status.id, $event)"
-              placeholder="Descrição rápida da etapa"
-            ></textarea>
-          </label>
-          <label class="status-field">
-            <span class="status-field__label">Ícone</span>
-            <div class="status-field__icon-select">
-              <span class="material-symbols-rounded" aria-hidden="true">{{ status.icon }}</span>
-              <select [value]="status.icon" (change)="onStatusIconChange(status.id, $event)">
-                <option *ngFor="let option of iconOptions" [value]="option.value">
-                  {{ option.label }}
-                </option>
-                <option *ngIf="!hasIconOption(status.icon)" [value]="status.icon">
-                  {{ status.icon }}
-                </option>
-              </select>
-            </div>
-          </label>
         </div>
       </li>
     </ul>
@@ -110,3 +106,11 @@
     </form>
   </section>
 </section>
+
+<hk-status-editor-modal
+  *ngIf="editingStatus() as status"
+  [status]="status"
+  [iconOptions]="iconOptions"
+  (dismissed)="closeStatusEditor()"
+  (submitted)="onStatusEditorSubmit($event)"
+></hk-status-editor-modal>

--- a/src/app/features/board-customizer/pages/board-customizer.page.scss
+++ b/src/app/features/board-customizer/pages/board-customizer.page.scss
@@ -48,15 +48,15 @@
   color: var(--hk-text-muted);
 }
 
-.board-customizer__statuses ul {
+.status-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1.25rem;
+  gap: 1rem;
 }
 
-.status-card {
+.status-item {
   display: grid;
   gap: 1rem;
   padding: 1.25rem;
@@ -66,13 +66,62 @@
   transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
-.status-card:hover,
-.status-card:focus-within {
+.status-item:hover,
+.status-item:focus-within {
   border-color: rgba(124, 92, 255, 0.45);
   background: rgba(124, 92, 255, 0.12);
 }
 
-.status-card__header {
+.status-item.cdk-drag-preview {
+  box-shadow: 0 24px 48px rgba(10, 12, 28, 0.6);
+  border-color: rgba(124, 92, 255, 0.65);
+}
+
+.status-item.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.status-list.cdk-drop-list-dragging .status-item:not(.cdk-drag-placeholder) {
+  transition: transform 0.2s ease;
+}
+
+.status-item__main {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.status-item__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  background: rgba(124, 92, 255, 0.2);
+  color: #f8fafc;
+  font-size: 1.8rem;
+}
+
+.status-item__info {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.status-item__title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.status-item__subtitle {
+  margin: 0;
+  color: var(--hk-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.status-item__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
@@ -80,13 +129,40 @@
   justify-content: space-between;
 }
 
-.status-card__reorder {
+.status-item__snacks {
   display: inline-flex;
-  gap: 0.35rem;
-  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-.status-card__reorder button {
+.status-item__snack {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.18);
+  border: 1px solid rgba(124, 92, 255, 0.35);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.status-item__snack--inactive {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+}
+
+.status-item__actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.status-item__drag-handle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -96,47 +172,22 @@
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(17, 24, 39, 0.7);
   color: inherit;
-  cursor: pointer;
+  cursor: grab;
   transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
-.status-card__reorder button:hover:not(:disabled),
-.status-card__reorder button:focus-visible:not(:disabled) {
+.status-item__drag-handle:active {
+  cursor: grabbing;
+}
+
+.status-item__drag-handle:hover,
+.status-item__drag-handle:focus-visible {
   transform: translateY(-1px);
   border-color: rgba(124, 92, 255, 0.6);
   background: rgba(124, 92, 255, 0.25);
 }
 
-.status-card__reorder button:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.status-card__identity {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  font-weight: 600;
-  color: var(--hk-text-muted);
-}
-
-.status-card__order {
-  font-size: 0.9rem;
-}
-
-.status-card__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-  background: rgba(124, 92, 255, 0.2);
-  color: #e2e8f0;
-  font-size: 1.6rem;
-}
-
-.status-card__toggle {
+.status-item__toggle {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -145,65 +196,31 @@
   cursor: pointer;
 }
 
-.status-card__toggle input {
+.status-item__toggle input {
   width: 1.1rem;
   height: 1.1rem;
   accent-color: #7c5cff;
 }
 
-.status-card__form {
-  display: grid;
-  gap: 1rem;
-}
-
-.status-field {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.status-field__label {
-  font-weight: 600;
-}
-
-.status-field input,
-.status-field textarea,
-.status-field select {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 0.9rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(8, 8, 18, 0.5);
-  color: inherit;
-  font: inherit;
-  resize: none;
-}
-
-.status-field textarea {
-  min-height: 3.5rem;
-}
-
-.status-field input:focus-visible,
-.status-field textarea:focus-visible,
-.status-field select:focus-visible {
-  outline: 2px solid rgba(124, 92, 255, 0.6);
-  outline-offset: 2px;
-}
-
-.status-field__icon-select {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.status-field__icon-select span.material-symbols-rounded {
+.status-item__edit {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 0.75rem;
-  background: rgba(124, 92, 255, 0.2);
-  color: #f8fafc;
+  gap: 0.35rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(124, 92, 255, 0.45);
+  background: rgba(124, 92, 255, 0.15);
+  color: #ede9fe;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease, border-color 0.2s ease;
+}
+
+.status-item__edit:hover,
+.status-item__edit:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+  border-color: rgba(124, 92, 255, 0.75);
 }
 
 .status-form__label {
@@ -263,13 +280,15 @@
     padding: clamp(1rem, 6vw, 2rem);
   }
 
-  .status-card__header {
+  .status-item__meta {
     flex-direction: column;
     align-items: flex-start;
+    gap: 0.75rem;
   }
 
-  .status-card__reorder {
-    order: 2;
+  .status-item__actions {
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .status-form__controls {

--- a/src/app/features/board-customizer/pages/board-customizer.page.ts
+++ b/src/app/features/board-customizer/pages/board-customizer.page.ts
@@ -1,7 +1,10 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { CdkDrag, CdkDragHandle, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 import { BoardConfigState } from '@features/board/state/board-config.state';
 import type { BoardStatusEditorOption } from '@features/board/state/board-config.state';
+import { StatusEditorModalComponent } from '../components/status-editor-modal/status-editor-modal.component';
+import type { StatusEditorFormValue } from '../components/status-editor-modal/status-editor-modal.component';
 
 @Component({
   selector: 'hk-board-customizer-page',
@@ -9,7 +12,7 @@ import type { BoardStatusEditorOption } from '@features/board/state/board-config
   templateUrl: './board-customizer.page.html',
   styleUrls: ['./board-customizer.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, NgIf],
+  imports: [NgFor, NgIf, StatusEditorModalComponent, CdkDropList, CdkDrag, CdkDragHandle],
 })
 export class BoardCustomizerPageComponent {
   private readonly boardConfig = inject(BoardConfigState);
@@ -17,6 +20,16 @@ export class BoardCustomizerPageComponent {
   protected readonly statuses = this.boardConfig.statusOptions;
   protected readonly newStatusName = this.boardConfig.newStatusName;
   protected readonly canCreateStatus = this.boardConfig.canCreateStatus;
+  protected readonly editingStatusId = signal<string | null>(null);
+  protected readonly editingStatus = computed(() => {
+    const targetId = this.editingStatusId();
+
+    if (!targetId) {
+      return null;
+    }
+
+    return this.statuses().find((status) => status.id === targetId) ?? null;
+  });
   protected readonly iconOptions: readonly IconOption[] = [
     { value: 'lightbulb', label: 'Ideação' },
     { value: 'rocket_launch', label: 'Preparação' },
@@ -59,42 +72,57 @@ export class BoardCustomizerPageComponent {
     this.boardConfig.addCustomStatus();
   }
 
-  protected onStatusTitleChange(statusId: string, event: Event): void {
-    const target = event.target;
+  protected onStatusDrop(event: CdkDragDrop<readonly BoardStatusEditorOption[]>): void {
+    const { previousIndex, currentIndex } = event;
 
-    if (!(target instanceof HTMLInputElement)) {
+    if (previousIndex === currentIndex) {
       return;
     }
 
-    this.boardConfig.updateStatusName(statusId, target.value);
-  }
+    const list = event.container.data ?? this.statuses();
+    const target =
+      (event.item.data as BoardStatusEditorOption | undefined) ??
+      list[previousIndex] ??
+      this.statuses()[previousIndex];
 
-  protected onStatusSubtitleChange(statusId: string, event: Event): void {
-    const target = event.target;
-
-    if (!(target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement)) {
+    if (!target) {
       return;
     }
 
-    this.boardConfig.updateStatusDescription(statusId, target.value);
+    this.boardConfig.reorderStatus(target.id, currentIndex);
   }
 
-  protected onStatusIconChange(statusId: string, event: Event): void {
-    const target = event.target;
+  protected openStatusEditor(statusId: string): void {
+    this.editingStatusId.set(statusId);
+  }
 
-    if (!(target instanceof HTMLSelectElement)) {
+  protected closeStatusEditor(): void {
+    this.editingStatusId.set(null);
+  }
+
+  protected onStatusEditorSubmit(update: StatusEditorFormValue): void {
+    const current = this.editingStatus();
+
+    if (!current) {
       return;
     }
 
-    this.boardConfig.updateStatusIcon(statusId, target.value);
-  }
+    const normalizedName = update.name.trim();
+    if (normalizedName.length > 0 && normalizedName !== current.name) {
+      this.boardConfig.updateStatusName(current.id, normalizedName);
+    }
 
-  protected onMoveStatus(statusId: string, direction: 'up' | 'down'): void {
-    this.boardConfig.moveStatus(statusId, direction);
-  }
+    const normalizedDescription = update.description.replace(/\s+/g, ' ').trim();
+    if (normalizedDescription !== current.description) {
+      this.boardConfig.updateStatusDescription(current.id, normalizedDescription);
+    }
 
-  protected hasIconOption(icon: string): boolean {
-    return this.iconOptions.some((option) => option.value === icon);
+    const normalizedIcon = update.icon.trim();
+    if (normalizedIcon !== current.icon) {
+      this.boardConfig.updateStatusIcon(current.id, normalizedIcon);
+    }
+
+    this.closeStatusEditor();
   }
 }
 

--- a/src/app/features/board/state/board-config.state.spec.ts
+++ b/src/app/features/board/state/board-config.state.spec.ts
@@ -83,16 +83,29 @@ describe('BoardConfigState', () => {
     expect(state.statuses()[2].icon).toBe('flag');
   });
 
-  it('should move statuses up and down updating their order', () => {
+  it('should reorder statuses when a new target index is provided', () => {
     const before = state.statusOptions().map((option) => option.id);
     const targetId = before[1];
 
-    state.moveStatus(targetId, 'up');
-    const afterUp = state.statusOptions().map((option) => option.id);
-    expect(afterUp[0]).toBe(targetId);
+    state.reorderStatus(targetId, 3);
+    const after = state.statusOptions().map((option) => option.id);
 
-    state.moveStatus(targetId, 'down');
-    const afterDown = state.statusOptions().map((option) => option.id);
-    expect(afterDown[1]).toBe(targetId);
+    expect(after[3]).toBe(targetId);
+  });
+
+  it('should clamp invalid reorder indices to the available range', () => {
+    const lastStatusId = state.statusOptions().at(-1)?.id;
+
+    if (!lastStatusId) {
+      fail('Expected at least one status option');
+      return;
+    }
+
+    state.reorderStatus(lastStatusId, -10);
+    expect(state.statusOptions()[0].id).toBe(lastStatusId);
+
+    state.reorderStatus(lastStatusId, 999);
+    const latest = state.statusOptions();
+    expect(latest[latest.length - 1].id).toBe(lastStatusId);
   });
 });

--- a/src/app/features/board/state/board-config.state.ts
+++ b/src/app/features/board/state/board-config.state.ts
@@ -257,7 +257,7 @@ export class BoardConfigState {
     );
   }
 
-  moveStatus(statusId: string, direction: 'up' | 'down'): void {
+  reorderStatus(statusId: string, targetIndex: number): void {
     this._statuses.update((statuses) => {
       const sorted = [...statuses].sort((a, b) => a.order - b.order);
       const currentIndex = sorted.findIndex((status) => status.id === statusId);
@@ -266,14 +266,17 @@ export class BoardConfigState {
         return statuses;
       }
 
-      const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+      const normalizedTargetIndex = Math.min(
+        Math.max(targetIndex, 0),
+        sorted.length - 1,
+      );
 
-      if (targetIndex < 0 || targetIndex >= sorted.length) {
+      if (normalizedTargetIndex === currentIndex) {
         return statuses;
       }
 
       const [moved] = sorted.splice(currentIndex, 1);
-      sorted.splice(targetIndex, 0, moved);
+      sorted.splice(normalizedTargetIndex, 0, moved);
 
       return sorted.map((status, index) => ({
         ...status,


### PR DESCRIPTION
## Summary
- replace the status list reorder arrows with a drag-and-drop handle and styling updates
- add drag-and-drop handling on the customizer page and route it to the state layer
- introduce a reorderStatus helper in the board config state and update its unit tests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea232c1f4833393cd45a443c681aa