### PR TITLE
feat(board-customizer): add full status creation form and deletion

### DIFF
--- a/src/app/features/board-customizer/pages/board-customizer.page.html
+++ b/src/app/features/board-customizer/pages/board-customizer.page.html
@@ -75,6 +75,16 @@
               <span class="material-symbols-rounded" aria-hidden="true">edit</span>
               Editar
             </button>
+
+            <button
+              type="button"
+              class="status-item__delete"
+              (click)="onDeleteStatus(status)"
+              [attr.aria-label]="'Remover etapa ' + status.name"
+            >
+              <span class="material-symbols-rounded" aria-hidden="true">delete</span>
+              Remover
+            </button>
           </div>
         </div>
       </li>
@@ -86,22 +96,63 @@
       <h2 id="status-create-heading">Criar nova etapa</h2>
       <p>Use nomes únicos com pelo menos três caracteres para manter o fluxo organizado.</p>
     </header>
-    <form (submit)="onStatusFormSubmit($event)" aria-label="Criar nova etapa do quadro">
-      <label class="status-form__label" for="new-status">Nome da etapa</label>
-      <div class="status-form__controls">
-        <input
-          id="new-status"
-          type="text"
-          name="new-status"
-          placeholder="Ex.: Em validação"
-          autocomplete="off"
-          [value]="newStatusName()"
-          (input)="onNewStatusNameInput($event)"
-        />
-        <button type="submit" [disabled]="!canCreateStatus()">Adicionar</button>
+    <form class="status-form" (submit)="onStatusFormSubmit($event)" aria-label="Criar nova etapa do quadro">
+      <div class="status-form__grid">
+        <label class="status-form__field" for="new-status-name">
+          <span>Nome da etapa</span>
+          <input
+            id="new-status-name"
+            type="text"
+            name="new-status-name"
+            placeholder="Ex.: Em validação"
+            autocomplete="off"
+            [value]="newStatusDraft().name"
+            (input)="onNewStatusNameInput($event)"
+            required
+            minlength="3"
+          />
+        </label>
+
+        <label class="status-form__field" for="new-status-description">
+          <span>Descrição</span>
+          <textarea
+            id="new-status-description"
+            name="new-status-description"
+            rows="3"
+            placeholder="Contexto exibido no quadro"
+            [value]="newStatusDraft().description"
+            (input)="onNewStatusDescriptionInput($event)"
+            required
+          ></textarea>
+        </label>
+
+        <label class="status-form__field status-form__field--icon" for="new-status-icon">
+          <span>Ícone</span>
+          <div class="status-form__icon-select">
+            <span class="material-symbols-rounded" aria-hidden="true">
+              {{ newStatusDraft().icon || 'flag' }}
+            </span>
+            <select
+              id="new-status-icon"
+              name="new-status-icon"
+              [value]="newStatusDraft().icon"
+              (change)="onNewStatusIconChange($event)"
+              required
+            >
+              <option *ngFor="let option of iconOptions" [value]="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </div>
+        </label>
       </div>
+
+      <div class="status-form__actions">
+        <button type="submit" [disabled]="!canCreateStatus()">Adicionar etapa</button>
+      </div>
+
       <p class="status-form__hint" *ngIf="!canCreateStatus()">
-        Informe um nome exclusivo com pelo menos 3 caracteres.
+        Informe um nome exclusivo, descrição e ícone para a nova etapa.
       </p>
     </form>
   </section>

--- a/src/app/features/board-customizer/pages/board-customizer.page.scss
+++ b/src/app/features/board-customizer/pages/board-customizer.page.scss
@@ -223,31 +223,89 @@
   border-color: rgba(124, 92, 255, 0.75);
 }
 
-.status-form__label {
+.status-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.status-form__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.status-form__field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.status-form__field span {
+  color: var(--hk-text-muted);
   font-weight: 600;
 }
 
-.status-form__controls {
-  display: flex;
-  gap: 0.85rem;
-}
-
-.status-form__controls input {
-  flex: 1;
+.status-form__field input,
+.status-form__field textarea,
+.status-form__field select {
   padding: 0.75rem 1rem;
   border-radius: 0.9rem;
   border: 1px solid rgba(255, 255, 255, 0.14);
   background: rgba(8, 8, 18, 0.5);
   color: inherit;
+  font: inherit;
 }
 
-.status-form__controls input:focus-visible {
+.status-form__field textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
+.status-form__field input:focus-visible,
+.status-form__field textarea:focus-visible,
+.status-form__field select:focus-visible {
   outline: 2px solid rgba(124, 92, 255, 0.6);
   outline-offset: 2px;
 }
 
-.status-form__controls button {
-  padding: 0.75rem 1.25rem;
+.status-form__field--icon {
+  align-self: end;
+}
+
+.status-form__icon-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(8, 8, 18, 0.5);
+}
+
+.status-form__icon-select span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  background: rgba(124, 92, 255, 0.2);
+  color: #f8fafc;
+  font-size: 1.6rem;
+}
+
+.status-form__icon-select select {
+  min-width: 12rem;
+  border: none;
+  background: transparent;
+  padding: 0.5rem 0;
+}
+
+.status-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.status-form__actions button {
+  padding: 0.75rem 1.35rem;
   border-radius: 0.9rem;
   border: none;
   font-weight: 600;
@@ -257,14 +315,14 @@
   transition: transform 0.2s ease, filter 0.2s ease;
 }
 
-.status-form__controls button:disabled {
+.status-form__actions button:disabled {
   cursor: not-allowed;
   filter: grayscale(0.4);
   opacity: 0.65;
 }
 
-.status-form__controls button:not(:disabled):hover,
-.status-form__controls button:not(:disabled):focus-visible {
+.status-form__actions button:not(:disabled):hover,
+.status-form__actions button:not(:disabled):focus-visible {
   transform: translateY(-1px);
   filter: brightness(1.05);
 }
@@ -291,11 +349,47 @@
     justify-content: flex-start;
   }
 
-  .status-form__controls {
-    flex-direction: column;
+  .status-form__grid {
+    grid-template-columns: 1fr;
   }
 
-  .status-form__controls button {
+  .status-form__actions {
+    justify-content: stretch;
+  }
+
+  .status-form__actions button {
     width: 100%;
   }
+}
+
+@media (min-width: 720px) {
+  .status-form__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .status-form__field--icon {
+    grid-column: span 2;
+    max-width: 22rem;
+  }
+}
+
+.status-item__delete {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(248, 113, 113, 0.55);
+  background: rgba(248, 113, 113, 0.15);
+  color: #fecaca;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease, border-color 0.2s ease;
+}
+
+.status-item__delete:hover,
+.status-item__delete:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+  border-color: rgba(248, 113, 113, 0.8);
 }

--- a/src/app/features/board-customizer/pages/board-customizer.page.ts
+++ b/src/app/features/board-customizer/pages/board-customizer.page.ts
@@ -18,7 +18,7 @@ export class BoardCustomizerPageComponent {
   private readonly boardConfig = inject(BoardConfigState);
 
   protected readonly statuses = this.boardConfig.statusOptions;
-  protected readonly newStatusName = this.boardConfig.newStatusName;
+  protected readonly newStatusDraft = this.boardConfig.newStatusDraft;
   protected readonly canCreateStatus = this.boardConfig.canCreateStatus;
   protected readonly editingStatusId = signal<string | null>(null);
   protected readonly editingStatus = computed(() => {
@@ -65,6 +65,26 @@ export class BoardCustomizerPageComponent {
     }
 
     this.boardConfig.updateNewStatusName(target.value);
+  }
+
+  protected onNewStatusDescriptionInput(event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLTextAreaElement)) {
+      return;
+    }
+
+    this.boardConfig.updateNewStatusDescription(target.value);
+  }
+
+  protected onNewStatusIconChange(event: Event): void {
+    const target = event.target;
+
+    if (!(target instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    this.boardConfig.updateNewStatusIcon(target.value);
   }
 
   protected onStatusFormSubmit(event: Event): void {
@@ -123,6 +143,22 @@ export class BoardCustomizerPageComponent {
     }
 
     this.closeStatusEditor();
+  }
+
+  protected onDeleteStatus(status: BoardStatusEditorOption): void {
+    const confirmation = confirm(
+      `Tem certeza de que deseja remover a etapa "${status.name}"? Essa ação não pode ser desfeita.`,
+    );
+
+    if (!confirmation) {
+      return;
+    }
+
+    this.boardConfig.removeStatus(status.id);
+
+    if (this.editingStatusId() === status.id) {
+      this.closeStatusEditor();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- require name, description, and icon when creating a board status with updated UI layout
- store draft status data in state and reset after creation while allowing icons and description customization
- allow removing statuses with confirmation and clean up transitions and styling for the new controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea7e8d26c8333a257a5c11ae8c55f