### PR TITLE
Simplify board columns and support sprint selection when creating stories

### DIFF
--- a/src/app/features/board/components/board-column/board-column.component.html
+++ b/src/app/features/board/components/board-column/board-column.component.html
@@ -3,39 +3,15 @@
   [class.column--active-drop]="isDragOver()"
   [class.column--invalid]="isDropRejected()"
   [attr.data-status]="column().status.id"
+  [attr.aria-label]="column().status.name"
   (dragenter)="onDragEnter($event)"
   (dragover)="onDragOver($event)"
   (dragleave)="onDragLeave($event)"
   (drop)="onDrop($event)"
 >
-  <header class="column__header">
-    <div class="column__identity">
-      <span class="column__icon" [style.background]="column().status.color" aria-hidden="true">
-        <span class="material-symbols-rounded">{{ column().status.icon }}</span>
-      </span>
-      <div>
-        <h3>{{ column().status.name }}</h3>
-        <p>{{ column().status.description }}</p>
-      </div>
-    </div>
-    <span
-      class="column__wip"
-      [class.column__wip--alert]="column().isWipLimitBreached"
-      role="status"
-      aria-live="polite"
-    >
-      {{ column().wipCount }} / {{ column().wipLimit ?? '∞' }} WIP
-    </span>
-  </header>
-
   <ul class="column__cards" role="list">
     <li *ngFor="let card of column().cards; trackBy: trackCard" role="listitem">
       <kanban-board-card [card]="card"></kanban-board-card>
-    </li>
-    <li *ngIf="column().cards.length === 0" class="column__empty">
-      <p>
-        Nada por aqui ainda. Conecte uma missão ou arraste uma história para desbloquear XP nesta etapa.
-      </p>
     </li>
   </ul>
 </article>

--- a/src/app/features/board/components/board-column/board-column.component.scss
+++ b/src/app/features/board/components/board-column/board-column.component.scss
@@ -47,59 +47,6 @@
   }
 }
 
-.column__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.75rem;
-  padding-bottom: 0.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.column__identity {
-  display: flex;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.column__icon {
-  display: grid;
-  place-items: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.75rem;
-  background: var(--hk-accent);
-  color: #0f0c29;
-}
-
-.column__icon .material-symbols-rounded {
-  font-variation-settings: 'FILL' 1, 'wght' 600, 'opsz' 32;
-}
-
-.column__identity h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.column__identity p {
-  margin: 0.2rem 0 0;
-  color: var(--hk-text-muted);
-  font-size: 0.85rem;
-}
-
-.column__wip {
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  font-size: 0.85rem;
-}
-
-.column__wip--alert {
-  background: rgba(248, 113, 113, 0.18);
-  color: var(--hk-danger);
-}
-
 .column__cards {
   margin: 0;
   padding: 0 0.35rem 0.5rem 0;
@@ -120,13 +67,3 @@
   background: rgba(255, 255, 255, 0.12);
 }
 
-.column__empty {
-  margin: 0;
-  padding: 1.25rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--hk-text-muted);
-  font-size: 0.9rem;
-  text-align: center;
-}

--- a/src/app/features/board/components/board-column/board-column.component.ts
+++ b/src/app/features/board/components/board-column/board-column.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, input, signal, inject } from '@angular/core';
-import { NgFor, NgIf } from '@angular/common';
+import { NgFor } from '@angular/common';
 import type { BoardColumnViewModel } from '../../state/board.models';
 import { BoardCardComponent } from '../board-card/board-card.component';
 import { BoardState } from '../../state/board-state.service';
@@ -11,7 +11,7 @@ import { BoardDragState } from '../../state/board-drag-state.service';
   templateUrl: './board-column.component.html',
   styleUrls: ['./board-column.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, NgIf, BoardCardComponent],
+  imports: [NgFor, BoardCardComponent],
 })
 export class BoardColumnComponent implements OnDestroy {
   readonly column = input.required<BoardColumnViewModel>();

--- a/src/app/features/board/components/create-story-modal/create-story-modal.component.html
+++ b/src/app/features/board/components/create-story-modal/create-story-modal.component.html
@@ -55,6 +55,16 @@
         </label>
 
         <label class="create-story-modal__field">
+          <span>Sprint</span>
+          <select formControlName="sprintId">
+            <option value="">Sem sprint</option>
+            <option *ngFor="let sprint of sprints()" [value]="sprint.id">
+              {{ formatSprintLabel(sprint) }}
+            </option>
+          </select>
+        </label>
+
+        <label class="create-story-modal__field">
           <span>Prioridade</span>
           <select formControlName="priority">
             <option *ngFor="let option of priorityOptions" [value]="option.value">{{ option.label }}</option>

--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -112,6 +112,8 @@
     *ngIf="isCreatingStory()"
     [features]="features()"
     [statusOptions]="statusOptions()"
+    [sprints]="sprints()"
+    [activeSprintId]="selectedSprintId()"
     (dismissed)="closeCreateStory()"
     (submitted)="onStorySubmitted($event)"
   ></kanban-create-story-modal>

--- a/src/app/features/board/pages/board.page.ts
+++ b/src/app/features/board/pages/board.page.ts
@@ -44,6 +44,7 @@ export class BoardPageComponent {
   protected readonly columns = this.boardState.columns;
   protected readonly summary = this.boardState.summary;
   protected readonly features = this.boardState.features;
+  protected readonly sprints = this.boardState.sprints;
   protected readonly statusOptions = this.boardState.statusOptions;
   protected readonly sprintOptions = this.boardState.sprintFilterOptions;
   protected readonly selectedSprintId = this.boardState.selectedSprintId;


### PR DESCRIPTION
## Summary
- remove the extra header, WIP counters and empty-state messaging so each column only shows story/task cards
- clean up the column styles after the markup change
- allow choosing a sprint when creating a story, preselecting the active sprint filter

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: No binary for ChromeHeadless browser on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68deb806fb048333bd6f7989f4f24c76