### PR TITLE
fix: adicionar rotulos nos cards de feature e historia

### DIFF
--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -87,6 +87,11 @@
     </mat-card>
   </div>
 
+  <p class="board__definition" role="note">
+    <strong>Tarefas</strong> representam os passos táticos para concluir uma história. Elas dividem o trabalho em pequenas ações
+    objetivas, dão visibilidade ao progresso diário e ajudam a planejar quem fará o quê em cada sprint.
+  </p>
+
   <section class="board__toolbar" aria-label="Filtros das tarefas">
     <div class="board__filters" role="region" aria-label="Filtrar tarefas por sprint">
       <mat-form-field appearance="fill" class="board__filter">

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -15,6 +15,20 @@
   gap: clamp(1.25rem, 3vw, 2rem);
 }
 
+.board__definition {
+  margin: 0;
+  padding: 0.9rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.32);
+  color: var(--hk-text-secondary);
+  line-height: 1.6;
+}
+
+.board__definition > strong {
+  color: var(--hk-text-primary);
+}
+
 @media (min-width: 1120px) {
   .board__overview {
     grid-template-columns: minmax(0, 2.15fr) minmax(0, 1.35fr);

--- a/src/app/features/board/pages/story-details/story-details.page.html
+++ b/src/app/features/board/pages/story-details/story-details.page.html
@@ -24,6 +24,10 @@
       <h1 id="story-details-title">{{ details.title }}</h1>
       <p class="story-details__theme">Tema: {{ details.featureTheme }}</p>
       <p class="story-details__mission">{{ details.featureMission }}</p>
+      <p class="story-details__definition" role="note">
+        <strong>Histórias</strong> traduzem necessidades do usuário em uma missão concreta para o squad. Elas descrevem o valor a
+        ser entregue, quem se beneficia e quais critérios indicam que a missão está completa.
+      </p>
     </header>
 
     <section class="story-details__meta" aria-label="Informações gerais da história">

--- a/src/app/features/board/pages/story-details/story-details.page.scss
+++ b/src/app/features/board/pages/story-details/story-details.page.scss
@@ -128,6 +128,20 @@
   max-width: 65ch;
 }
 
+.story-details__definition {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  color: var(--hk-text-secondary);
+  line-height: 1.6;
+}
+
+.story-details__definition > strong {
+  color: var(--hk-text-primary);
+}
+
 .story-details__meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.html
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.html
@@ -5,6 +5,10 @@
       <p>
         Conheça as missões épicas em andamento. Cada feature reúne histórias que impulsionam a jornada da guilda.
       </p>
+      <p class="catalog__definition" role="note">
+        <strong>Feature</strong> é uma iniciativa épica que orienta a estratégia do produto e agrupa histórias relacionadas.
+        Cada história detalha uma entrega de valor que, quando concluída, avança a guilda rumo ao objetivo da feature.
+      </p>
     </div>
     <button type="button" mat-flat-button color="primary" class="catalog__cta" (click)="openCreateFeatureDialog()">
       <mat-icon fontSet="material-symbols-rounded">add</mat-icon>
@@ -20,6 +24,7 @@
         class="feature-card"
       >
         <header class="feature-card__header">
+          <span class="feature-card__type" aria-label="Tipo de item">Feature</span>
           <h2>{{ feature.title }}</h2>
           <p class="feature-card__theme">{{ feature.theme }}</p>
         </header>

--- a/src/app/features/feature-explorer/pages/feature-catalog.page.scss
+++ b/src/app/features/feature-explorer/pages/feature-catalog.page.scss
@@ -29,6 +29,20 @@
   font-size: 1.05rem;
 }
 
+.catalog__definition {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(124, 92, 255, 0.12);
+  border: 1px solid rgba(124, 92, 255, 0.35);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.catalog__definition > strong {
+  color: var(--hk-text-primary);
+}
+
 .catalog__cta {
   align-self: flex-start;
   display: inline-flex;
@@ -66,7 +80,20 @@
 
 .feature-card__header {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.5rem;
+}
+
+.feature-card__type {
+  justify-self: flex-start;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.18);
+  border: 1px solid rgba(124, 92, 255, 0.45);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--hk-text-primary);
 }
 
 .feature-card__header > h2 {

--- a/src/app/features/feature-explorer/pages/feature-detail.page.html
+++ b/src/app/features/feature-explorer/pages/feature-detail.page.html
@@ -44,8 +44,11 @@
             class="story-card"
           >
             <header class="story-card__header">
-              <span class="story-card__status" [style.backgroundColor]="story.statusColor">{{ story.statusLabel }}</span>
-              <span class="story-card__priority" [style.color]="story.priorityColor">{{ story.priorityLabel }}</span>
+              <span class="story-card__type" aria-label="Tipo de item">História</span>
+              <div class="story-card__badge-row">
+                <span class="story-card__status" [style.backgroundColor]="story.statusColor">{{ story.statusLabel }}</span>
+                <span class="story-card__priority" [style.color]="story.priorityColor">{{ story.priorityLabel }}</span>
+              </div>
             </header>
 
             <h3 class="story-card__title">{{ story.title }}</h3>

--- a/src/app/features/feature-explorer/pages/feature-detail.page.scss
+++ b/src/app/features/feature-explorer/pages/feature-detail.page.scss
@@ -149,9 +149,28 @@
 }
 
 .story-card__header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.story-card__type {
+  justify-self: flex-start;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.2);
+  border: 1px solid rgba(99, 102, 241, 0.45);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--hk-text-primary);
+}
+
+.story-card__badge-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .story-card__status {


### PR DESCRIPTION
## Summary
- adiciona uma badge "Feature" em cada card do catálogo para reforçar o tipo do item
- exibe uma etiqueta "História" nos cards vinculados na tela de detalhes de feature, mantendo o layout das demais informações
- estiliza as novas badges de acordo com a paleta atual para garantir contraste e legibilidade

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68def8b8c5c8833396fc5e3721b5038a