### PR TITLE
Restore board column headers with status metadata

### DIFF
--- a/src/app/features/board/components/board-column/board-column.component.html
+++ b/src/app/features/board/components/board-column/board-column.component.html
@@ -4,11 +4,32 @@
   [class.column--invalid]="isDropRejected()"
   [attr.data-status]="column().status.id"
   [attr.aria-label]="column().status.name"
+  [attr.aria-describedby]="'column-description-' + column().status.id"
+  [style.--status-color]="column().status.color"
   (dragenter)="onDragEnter($event)"
   (dragover)="onDragOver($event)"
   (dragleave)="onDragLeave($event)"
   (drop)="onDrop($event)"
 >
+  <header class="column__header">
+    <div class="column__identity">
+      <span class="column__icon" aria-hidden="true">
+        <mat-icon fontSet="material-symbols-rounded">{{ column().status.icon }}</mat-icon>
+      </span>
+      <div class="column__titles">
+        <p class="column__name">{{ column().status.name }}</p>
+        <p class="column__description" [id]="'column-description-' + column().status.id">
+          {{ column().status.description }}
+        </p>
+      </div>
+    </div>
+    <div class="column__meta" role="status" [attr.aria-label]="wipAriaLabel()">
+      <span class="column__short-label" aria-hidden="true">{{ column().status.shortLabel }}</span>
+      <span class="column__wip" [class.column__wip--breached]="column().isWipLimitBreached">
+        {{ wipDisplayLabel() }}
+      </span>
+    </div>
+  </header>
   <ul class="column__cards" role="list">
     <li *ngFor="let card of column().cards; trackBy: trackCard" role="listitem">
       <kanban-board-card [card]="card"></kanban-board-card>

--- a/src/app/features/board/components/board-column/board-column.component.scss
+++ b/src/app/features/board/components/board-column/board-column.component.scss
@@ -10,7 +10,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
   background: var(--hk-surface);
   border: 1px solid var(--hk-border);
   border-radius: 1rem;
@@ -18,6 +18,7 @@
   min-height: 24rem;
   height: 100%;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  --status-color: var(--hk-accent);
 }
 
 .column--active-drop {
@@ -45,6 +46,97 @@
   75% {
     transform: translateX(-2px);
   }
+}
+
+.column__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.column__identity {
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.column__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.85rem;
+  color: var(--status-color);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+  background: color-mix(in srgb, var(--status-color) 18%, transparent);
+  border-color: color-mix(in srgb, var(--status-color) 55%, transparent);
+  box-shadow: 0 12px 30px rgba(9, 7, 32, 0.55);
+  font-size: 1.45rem;
+}
+
+.column__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.column__name {
+  margin: 0;
+  font-family: var(--hk-heading-font-family);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--hk-text-primary);
+  text-transform: uppercase;
+}
+
+.column__description {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--hk-text-muted);
+}
+
+.column__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.column__short-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--status-color) 78%, rgba(255, 255, 255, 0.55));
+}
+
+.column__wip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.25rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--hk-text-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.column__wip--breached {
+  background: rgba(248, 113, 113, 0.12);
+  background: color-mix(in srgb, var(--hk-danger) 18%, transparent);
+  color: var(--hk-danger);
+  border-color: rgba(248, 113, 113, 0.35);
+  border-color: color-mix(in srgb, var(--hk-danger) 45%, transparent);
 }
 
 .column__cards {

--- a/src/app/features/board/components/board-column/board-column.component.ts
+++ b/src/app/features/board/components/board-column/board-column.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, input, signal, inject } from '@angular/core';
 import { NgFor } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import type { BoardColumnViewModel } from '../../state/board.models';
 import { BoardCardComponent } from '../board-card/board-card.component';
 import { BoardState } from '../../state/board-state.service';
@@ -11,7 +12,7 @@ import { BoardDragState } from '../../state/board-drag-state.service';
   templateUrl: './board-column.component.html',
   styleUrls: ['./board-column.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, BoardCardComponent],
+  imports: [NgFor, BoardCardComponent, MatIconModule],
 })
 export class BoardColumnComponent implements OnDestroy {
   readonly column = input.required<BoardColumnViewModel>();
@@ -21,6 +22,27 @@ export class BoardColumnComponent implements OnDestroy {
   private readonly boardState = inject(BoardState);
   private readonly dragState = inject(BoardDragState);
   private dropFeedbackTimeoutId: number | undefined;
+
+  protected wipDisplayLabel(): string {
+    const column = this.column();
+    if (column.wipLimit !== undefined) {
+      return `${column.wipCount} / ${column.wipLimit}`;
+    }
+
+    return `${column.wipCount}`;
+  }
+
+  protected wipAriaLabel(): string {
+    const column = this.column();
+    if (column.wipLimit !== undefined) {
+      const prefix = column.isWipLimitBreached ? 'Limite de WIP excedido' : 'Limite de WIP';
+      const pluralized = column.wipCount === 1 ? 'história' : 'histórias';
+      return `${prefix}: ${column.wipCount} de ${column.wipLimit} ${pluralized}`;
+    }
+
+    const pluralized = column.wipCount === 1 ? 'história' : 'histórias';
+    return `${column.wipCount} ${pluralized} em andamento`;
+  }
 
   protected trackCard(_: number, card: BoardColumnViewModel['cards'][number]): string {
     return card.id;


### PR DESCRIPTION
## Summary
- restore the kanban column header layout with status icon, description, and short label
- show WIP counts and limits with accessible labels and styling for breaches
- update column styling to visually align the header and highlight status colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dff3d069f48333bcd2364ddd4a8955