### PR TITLE
feat: allow creating new sprint from planning page

### DIFF
--- a/src/app/features/board/state/board-state.service.spec.ts
+++ b/src/app/features/board/state/board-state.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { BoardState } from './board-state.service';
-import type { CreateStoryPayload } from './board.models';
+import type { CreateSprintPayload, CreateStoryPayload } from './board.models';
 
 describe('BoardState', () => {
   let service: BoardState;
@@ -120,5 +120,33 @@ describe('BoardState', () => {
 
     service.setSprintFilter('unknown-sprint');
     expect(service.selectedSprintId()).toBe('all-sprints');
+  });
+
+  it('should create a new sprint when the payload is valid', () => {
+    const payload: CreateSprintPayload = {
+      name: 'Sprint Aurora',
+      goal: 'Lançar o painel cooperativo de conquistas.',
+      focus: 'Integrações e alinhamento com comunidades',
+      startDateIso: '2024-07-01',
+      endDateIso: '2024-07-12',
+    };
+
+    const created = service.createSprint(payload);
+    expect(created).not.toBeNull();
+    expect(service.sprints().some((sprint) => sprint.id === created?.id)).toBeTrue();
+    expect(service.sprintOverviews().some((overview) => overview.sprint.id === created?.id)).toBeTrue();
+  });
+
+  it('should block sprint creation when the period is invalid', () => {
+    const payload: CreateSprintPayload = {
+      name: 'Sprint Eclipse',
+      goal: 'Preparar o lançamento do hub de insights.',
+      focus: 'Dados e confiabilidade',
+      startDateIso: '2024-08-15',
+      endDateIso: '2024-08-10',
+    };
+
+    const created = service.createSprint(payload);
+    expect(created).toBeNull();
   });
 });

--- a/src/app/features/board/state/board-state.service.ts
+++ b/src/app/features/board/state/board-state.service.ts
@@ -5,6 +5,7 @@ import type {
   BoardStatus,
   BoardStatusWithCapacity,
   CreateFeaturePayload,
+  CreateSprintPayload,
   CreateStoryPayload,
   Feature,
   Mission,
@@ -106,6 +107,42 @@ export class BoardState {
       endDateIso: '2024-06-28',
     },
   ]);
+
+  createSprint(payload: CreateSprintPayload): Sprint | null {
+    const name = payload.name.trim();
+    const goal = payload.goal.trim();
+    const focus = payload.focus.trim();
+    const startDateIso = payload.startDateIso.trim();
+    const endDateIso = payload.endDateIso.trim();
+
+    if (name.length < 3 || goal.length < 5 || focus.length < 3) {
+      return null;
+    }
+
+    const startTimestamp = Date.parse(startDateIso);
+    const endTimestamp = Date.parse(endDateIso);
+
+    if (Number.isNaN(startTimestamp) || Number.isNaN(endTimestamp) || startTimestamp > endTimestamp) {
+      return null;
+    }
+
+    const sprint: Sprint = {
+      id: this.createId('sprint'),
+      name,
+      goal,
+      focus,
+      startDateIso,
+      endDateIso,
+    };
+
+    this._sprints.update((current) => {
+      const next = [...current, sprint];
+      next.sort((a, b) => Date.parse(a.startDateIso) - Date.parse(b.startDateIso));
+      return next;
+    });
+
+    return sprint;
+  }
 
   private readonly _selectedSprintId = signal<string>(ALL_SPRINTS_FILTER);
 

--- a/src/app/features/board/state/board.models.ts
+++ b/src/app/features/board/state/board.models.ts
@@ -34,6 +34,14 @@ export interface Sprint {
   readonly endDateIso: string;
 }
 
+export interface CreateSprintPayload {
+  readonly name: string;
+  readonly goal: string;
+  readonly focus: string;
+  readonly startDateIso: string;
+  readonly endDateIso: string;
+}
+
 export interface SprintFilterOption {
   readonly id: string;
   readonly label: string;

--- a/src/app/features/sprints/components/create-sprint-modal/create-sprint-modal.component.html
+++ b/src/app/features/sprints/components/create-sprint-modal/create-sprint-modal.component.html
@@ -1,0 +1,68 @@
+<section class="create-sprint-modal" (keydown.escape)="onCancel()">
+  <div class="create-sprint-modal__backdrop" (click)="onCancel()" aria-hidden="true"></div>
+  <div class="create-sprint-modal__panel" role="dialog" aria-modal="true" aria-labelledby="create-sprint-title">
+    <form class="create-sprint-modal__form" (ngSubmit)="onSubmit()" novalidate>
+      <header class="create-sprint-modal__header">
+        <div>
+          <h2 id="create-sprint-title">Cadastrar nova sprint</h2>
+          <p>Planeje o próximo ciclo com objetivo claro, foco estratégico e datas alinhadas à guilda.</p>
+        </div>
+        <button type="button" class="create-sprint-modal__close" (click)="onCancel()" aria-label="Fechar modal">
+          <span class="material-symbols-rounded" aria-hidden="true">close</span>
+        </button>
+      </header>
+
+      <div class="create-sprint-modal__grid">
+        <label class="create-sprint-modal__field">
+          <span>Nome da sprint</span>
+          <input type="text" formControlName="name" placeholder="Ex.: Sprint Aurora" />
+          <small *ngIf="form.controls.name.invalid && form.controls.name.touched">
+            Informe um nome com pelo menos 3 caracteres.
+          </small>
+        </label>
+
+        <label class="create-sprint-modal__field">
+          <span>Objetivo</span>
+          <textarea formControlName="goal" rows="3" placeholder="Defina o resultado esperado para o squad"></textarea>
+          <small *ngIf="form.controls.goal.invalid && form.controls.goal.touched">
+            Explique o objetivo estratégico da sprint.
+          </small>
+        </label>
+
+        <label class="create-sprint-modal__field">
+          <span>Foco estratégico</span>
+          <input type="text" formControlName="focus" placeholder="Ex.: Integrações e estabilidade" />
+          <small *ngIf="form.controls.focus.invalid && form.controls.focus.touched">
+            Descreva o foco principal da guilda nesta sprint.
+          </small>
+        </label>
+
+        <div class="create-sprint-modal__dates">
+          <label class="create-sprint-modal__field">
+            <span>Início</span>
+            <input type="date" formControlName="startDate" />
+            <small *ngIf="form.controls.startDate.invalid && form.controls.startDate.touched">
+              Informe a data de início da sprint.
+            </small>
+          </label>
+
+          <label class="create-sprint-modal__field">
+            <span>Término</span>
+            <input type="date" formControlName="endDate" />
+            <small *ngIf="form.controls.endDate.invalid && form.controls.endDate.touched">
+              Informe a data de término da sprint.
+            </small>
+            <small *ngIf="hasInvalidPeriod">A data final deve ser posterior ou igual ao início.</small>
+          </label>
+        </div>
+      </div>
+
+      <footer class="create-sprint-modal__footer">
+        <button type="button" class="create-sprint-modal__secondary" (click)="onCancel()">Cancelar</button>
+        <button type="submit" class="create-sprint-modal__primary" [disabled]="form.invalid || hasInvalidPeriod">
+          Salvar sprint
+        </button>
+      </footer>
+    </form>
+  </div>
+</section>

--- a/src/app/features/sprints/components/create-sprint-modal/create-sprint-modal.component.scss
+++ b/src/app/features/sprints/components/create-sprint-modal/create-sprint-modal.component.scss
@@ -1,0 +1,190 @@
+.create-sprint-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 2.5rem);
+}
+
+.create-sprint-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(13, 17, 28, 0.75);
+  backdrop-filter: blur(10px);
+}
+
+.create-sprint-modal__panel {
+  position: relative;
+  width: min(560px, 100%);
+  max-height: calc(100vh - 2 * clamp(1rem, 4vw, 2.5rem));
+  border-radius: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.9));
+  box-shadow: 0 35px 80px -25px rgba(12, 10, 36, 0.6);
+  overflow: hidden;
+  color: var(--hk-text-primary);
+}
+
+.create-sprint-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.create-sprint-modal__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.create-sprint-modal__header h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.4vw, 2.1rem);
+  font-weight: 600;
+}
+
+.create-sprint-modal__header p {
+  margin: 0.5rem 0 0;
+  color: var(--hk-text-secondary);
+  max-width: 48ch;
+}
+
+.create-sprint-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.create-sprint-modal__close:hover,
+.create-sprint-modal__close:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(var(--hk-accent-rgb), 0.7);
+  background: rgba(var(--hk-accent-rgb), 0.25);
+}
+
+.create-sprint-modal__grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.create-sprint-modal__dates {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .create-sprint-modal__dates {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+  }
+}
+
+.create-sprint-modal__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.create-sprint-modal__field > span {
+  font-size: 0.95rem;
+  color: var(--hk-text-muted);
+}
+
+.create-sprint-modal__field input,
+.create-sprint-modal__field textarea {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font: inherit;
+}
+
+.create-sprint-modal__field textarea {
+  resize: vertical;
+  min-height: 6.5rem;
+}
+
+.create-sprint-modal__field input:focus-visible,
+.create-sprint-modal__field textarea:focus-visible {
+  outline: none;
+  border-color: rgba(var(--hk-accent-rgb), 0.6);
+  box-shadow: 0 0 0 3px rgba(var(--hk-accent-rgb), 0.2);
+}
+
+.create-sprint-modal__field small {
+  font-size: 0.8rem;
+  color: #fda4af;
+}
+
+.create-sprint-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.create-sprint-modal__secondary,
+.create-sprint-modal__primary {
+  border-radius: 999px;
+  padding: 0.85rem 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.create-sprint-modal__secondary {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--hk-text-secondary);
+}
+
+.create-sprint-modal__secondary:hover,
+.create-sprint-modal__secondary:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(var(--hk-accent-rgb), 0.65);
+  color: var(--hk-text-primary);
+}
+
+.create-sprint-modal__primary {
+  background: linear-gradient(135deg, rgba(var(--hk-accent-rgb), 0.9), rgba(59, 130, 246, 0.85));
+  border: none;
+  color: #0b1120;
+  box-shadow: 0 18px 40px -18px rgba(37, 99, 235, 0.9);
+}
+
+.create-sprint-modal__primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.create-sprint-modal__primary:not(:disabled):hover,
+.create-sprint-modal__primary:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 50px -18px rgba(37, 99, 235, 0.95);
+}
+
+@media (max-width: 520px) {
+  .create-sprint-modal__footer {
+    flex-direction: column;
+  }
+
+  .create-sprint-modal__secondary,
+  .create-sprint-modal__primary {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/src/app/features/sprints/components/create-sprint-modal/create-sprint-modal.component.ts
+++ b/src/app/features/sprints/components/create-sprint-modal/create-sprint-modal.component.ts
@@ -1,0 +1,72 @@
+import { ChangeDetectionStrategy, Component, inject, output } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CreateSprintPayload } from '@features/board/state/board.models';
+
+@Component({
+  selector: 'hk-create-sprint-modal',
+  standalone: true,
+  templateUrl: './create-sprint-modal.component.html',
+  styleUrls: ['./create-sprint-modal.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgIf, ReactiveFormsModule],
+})
+export class CreateSprintModalComponent {
+  readonly dismissed = output<void>();
+  readonly submitted = output<CreateSprintPayload>();
+
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+
+  protected readonly form = this.formBuilder.group({
+    name: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    goal: this.formBuilder.control('', [Validators.required, Validators.minLength(5)]),
+    focus: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    startDate: this.formBuilder.control('', Validators.required),
+    endDate: this.formBuilder.control('', Validators.required),
+  });
+
+  protected get hasInvalidPeriod(): boolean {
+    const start = this.form.controls.startDate.value;
+    const end = this.form.controls.endDate.value;
+
+    if (!start || !end) {
+      return false;
+    }
+
+    return new Date(start).getTime() > new Date(end).getTime();
+  }
+
+  protected onCancel(): void {
+    this.dismissed.emit();
+    this.resetForm();
+  }
+
+  protected onSubmit(): void {
+    if (this.form.invalid || this.hasInvalidPeriod) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const value = this.form.getRawValue();
+    const payload: CreateSprintPayload = {
+      name: value.name.trim(),
+      goal: value.goal.trim(),
+      focus: value.focus.trim(),
+      startDateIso: value.startDate,
+      endDateIso: value.endDate,
+    };
+
+    this.submitted.emit(payload);
+    this.resetForm();
+  }
+
+  private resetForm(): void {
+    this.form.reset({
+      name: '',
+      goal: '',
+      focus: '',
+      startDate: '',
+      endDate: '',
+    });
+  }
+}

--- a/src/app/features/sprints/pages/sprints.page.html
+++ b/src/app/features/sprints/pages/sprints.page.html
@@ -7,9 +7,9 @@
         squad antes das cerimônias e garantir que nenhuma tarefa épica fique de fora.
       </p>
     </div>
-    <button type="button" class="sprints__new-task">
-      <span class="sprints__new-task-icon" aria-hidden="true">playlist_add</span>
-      Nova tarefa
+    <button type="button" class="sprints__new-sprint" (click)="openCreateSprint()">
+      <span class="sprints__new-sprint-icon" aria-hidden="true">playlist_add</span>
+      Nova sprint
     </button>
   </header>
 
@@ -86,3 +86,9 @@
     </section>
   </ng-template>
 </section>
+
+<hk-create-sprint-modal
+  *ngIf="isCreatingSprint()"
+  (dismissed)="closeCreateSprint()"
+  (submitted)="onSprintSubmitted($event)"
+></hk-create-sprint-modal>

--- a/src/app/features/sprints/pages/sprints.page.scss
+++ b/src/app/features/sprints/pages/sprints.page.scss
@@ -39,7 +39,7 @@
   max-width: 62ch;
 }
 
-.sprints__new-task {
+.sprints__new-sprint {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -53,14 +53,14 @@
   transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
 }
 
-.sprints__new-task:hover,
-.sprints__new-task:focus-visible {
+.sprints__new-sprint:hover,
+.sprints__new-sprint:focus-visible {
   transform: translateY(-1px);
   border-color: rgba(var(--hk-accent-rgb), 0.65);
   background: rgba(var(--hk-accent-rgb), 0.25);
 }
 
-.sprints__new-task-icon {
+.sprints__new-sprint-icon {
   font-family: 'Material Symbols Rounded';
   font-weight: 400;
   font-style: normal;
@@ -77,7 +77,7 @@
 }
 
 @media (max-width: 719px) {
-  .sprints__new-task {
+  .sprints__new-sprint {
     width: 100%;
     justify-content: center;
   }

--- a/src/app/features/sprints/pages/sprints.page.ts
+++ b/src/app/features/sprints/pages/sprints.page.ts
@@ -1,6 +1,8 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 import { BoardState } from '../../board/state/board-state.service';
+import type { CreateSprintPayload } from '../../board/state/board.models';
+import { CreateSprintModalComponent } from '../components/create-sprint-modal/create-sprint-modal.component';
 
 @Component({
   selector: 'hk-sprints-page',
@@ -8,7 +10,7 @@ import { BoardState } from '../../board/state/board-state.service';
   templateUrl: './sprints.page.html',
   styleUrls: ['./sprints.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, NgIf],
+  imports: [NgFor, NgIf, CreateSprintModalComponent],
 })
 export class SprintsPageComponent {
   private readonly boardState = inject(BoardState);
@@ -18,4 +20,20 @@ export class SprintsPageComponent {
   protected readonly trackStory = this.boardState.trackSprintStory;
   protected readonly trackTask = this.boardState.trackSprintTask;
   protected readonly hasSprints = computed(() => this.sprintOverviews().length > 0);
+  protected readonly isCreatingSprint = signal(false);
+
+  protected openCreateSprint(): void {
+    this.isCreatingSprint.set(true);
+  }
+
+  protected closeCreateSprint(): void {
+    this.isCreatingSprint.set(false);
+  }
+
+  protected onSprintSubmitted(payload: CreateSprintPayload): void {
+    const created = this.boardState.createSprint(payload);
+    if (created) {
+      this.isCreatingSprint.set(false);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add a standalone modal component to register new sprints with validation
- wire the planning page button to open the modal and submit data to the board state
- extend the board state with sprint creation logic and unit tests covering happy and invalid paths

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68e01436eec48333927cb734a119dfe9