### PR TITLE
refactor: lazy load feature pages per route

### DIFF
--- a/src/app/features/board-customizer/board-customizer.routes.ts
+++ b/src/app/features/board-customizer/board-customizer.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
-import { BoardCustomizerPageComponent } from './pages/board-customizer.page';
 
 export const BOARD_CUSTOMIZER_ROUTES: Routes = [
   {
     path: '',
-    component: BoardCustomizerPageComponent,
+    loadComponent: () =>
+      import('./pages/board-customizer.page').then(
+        (m) => m.BoardCustomizerPageComponent,
+      ),
   },
 ];

--- a/src/app/features/board/board.routes.ts
+++ b/src/app/features/board/board.routes.ts
@@ -1,16 +1,18 @@
 import { Routes } from '@angular/router';
-import { BoardPageComponent } from './pages/board.page';
-import { StoryDetailsPageComponent } from './pages/story-details/story-details.page';
 
 export const BOARD_ROUTES: Routes = [
   {
     path: 'historia/:storyId',
-    component: StoryDetailsPageComponent,
+    loadComponent: () =>
+      import('./pages/story-details/story-details.page').then(
+        (m) => m.StoryDetailsPageComponent,
+      ),
     title: 'Hero Kanban — Detalhes da história',
   },
   {
     path: '',
-    component: BoardPageComponent,
+    loadComponent: () =>
+      import('./pages/board.page').then((m) => m.BoardPageComponent),
     pathMatch: 'full',
     title: 'Hero Kanban — Missões do Time',
   },

--- a/src/app/features/feature-explorer/feature-explorer.routes.ts
+++ b/src/app/features/feature-explorer/feature-explorer.routes.ts
@@ -1,14 +1,14 @@
 import { Routes } from '@angular/router';
-import { FeatureCatalogPage } from './pages/feature-catalog.page';
-import { FeatureDetailPage } from './pages/feature-detail.page';
 
 export const FEATURE_EXPLORER_ROUTES: Routes = [
   {
     path: '',
-    component: FeatureCatalogPage,
+    loadComponent: () =>
+      import('./pages/feature-catalog.page').then((m) => m.FeatureCatalogPage),
   },
   {
     path: ':featureId',
-    component: FeatureDetailPage,
+    loadComponent: () =>
+      import('./pages/feature-detail.page').then((m) => m.FeatureDetailPage),
   },
 ];

--- a/src/app/features/profile/profile.routes.ts
+++ b/src/app/features/profile/profile.routes.ts
@@ -1,9 +1,9 @@
 import { Routes } from '@angular/router';
-import { ProfilePageComponent } from './pages/profile.page';
 
 export const PROFILE_ROUTES: Routes = [
   {
     path: '',
-    component: ProfilePageComponent,
+    loadComponent: () =>
+      import('./pages/profile.page').then((m) => m.ProfilePageComponent),
   },
 ];

--- a/src/app/features/sprints/sprints.routes.ts
+++ b/src/app/features/sprints/sprints.routes.ts
@@ -1,10 +1,10 @@
 import { Routes } from '@angular/router';
-import { SprintsPageComponent } from './pages/sprints.page';
 
 export const SPRINTS_ROUTES: Routes = [
   {
     path: '',
-    component: SprintsPageComponent,
+    loadComponent: () =>
+      import('./pages/sprints.page').then((m) => m.SprintsPageComponent),
     title: 'Hero Kanban — Planejamento de Sprints',
   },
 ];


### PR DESCRIPTION
## Summary
- switch feature routes to use loadComponent so every page is lazy-loaded independently
- ensure each standalone screen gets its own bundle via dynamic imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0691c23a8833396013272807156fc