### PR TITLE
feat: add new hero kanban themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Os testes cobrem o shell principal e regras de negócio dos serviços de estado 
 
 ### Perfil do herói (`/perfil`)
 - Consome `HeroControlState` para mostrar nível, conquistas e itens obtidos pela guilda.
-- `ThemeState` habilita seleção dinâmica entre os temas **Noite Estelar** e **Aurora Boreal**, atualizando tokens de cor globais.
+- `ThemeState` habilita seleção dinâmica entre as paletas **Noite Estelar**, **Aurora Boreal**, **Aurora Matinal**, **Forja em Brasas** e **Neblina Quântica**, atualizando tokens de cor globais.
 - Componentização standalone facilita futuras expansões como loja ou ranking.
 
 ## Próximos passos sugeridos

--- a/src/app/core/state/theme.state.spec.ts
+++ b/src/app/core/state/theme.state.spec.ts
@@ -23,11 +23,18 @@ describe('ThemeState', () => {
     expect(documentRef.documentElement.dataset['theme']).toBe('stellar-night');
   });
 
-  it('should change the theme when a valid option is selected', () => {
-    state.setTheme('aurora-crest');
+  it('should expose the available themes with their tone metadata', () => {
+    const themes = state.themes();
 
-    expect(state.currentTheme()).toBe('aurora-crest');
-    expect(documentRef.documentElement.dataset['theme']).toBe('aurora-crest');
+    expect(themes.length).toBeGreaterThanOrEqual(5);
+    expect(themes.some((theme) => theme.id === 'radiant-dawn' && theme.tone === 'light')).toBeTrue();
+  });
+
+  it('should change the theme when a valid option is selected', () => {
+    state.setTheme('radiant-dawn');
+
+    expect(state.currentTheme()).toBe('radiant-dawn');
+    expect(documentRef.documentElement.dataset['theme']).toBe('radiant-dawn');
   });
 
   it('should ignore unknown theme identifiers', () => {

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -1,7 +1,12 @@
 import { DOCUMENT } from '@angular/common';
 import { inject, Injectable, signal } from '@angular/core';
 
-export type ThemeId = 'stellar-night' | 'aurora-crest';
+export type ThemeId =
+  | 'stellar-night'
+  | 'aurora-crest'
+  | 'radiant-dawn'
+  | 'ember-forge'
+  | 'quantum-mist';
 
 export interface ThemeOption {
   readonly id: ThemeId;
@@ -38,6 +43,36 @@ export class ThemeState {
       previewGradient: 'linear-gradient(135deg, #012a4a 0%, #036666 100%)',
       tone: 'dark',
       previewFontFamily: "'Space Grotesk', 'Rubik', 'Segoe UI', sans-serif",
+    },
+    {
+      id: 'radiant-dawn',
+      label: 'Aurora Matinal',
+      description: 'Tema claro com foco em clareza e contrastes azulados.',
+      accent: '#2563eb',
+      softAccent: 'rgba(37, 99, 235, 0.18)',
+      previewGradient: 'linear-gradient(135deg, #f1f5ff 0%, #cfe1ff 100%)',
+      tone: 'light',
+      previewFontFamily: "'Inter', 'Segoe UI', sans-serif",
+    },
+    {
+      id: 'ember-forge',
+      label: 'Forja em Brasas',
+      description: 'Paleta vibrante inspirada em brasas e metais aquecidos.',
+      accent: '#f97316',
+      softAccent: 'rgba(249, 115, 22, 0.22)',
+      previewGradient: 'linear-gradient(135deg, #2d1b18 0%, #7c2d12 100%)',
+      tone: 'dark',
+      previewFontFamily: "'Rubik', 'Inter', 'Segoe UI', sans-serif",
+    },
+    {
+      id: 'quantum-mist',
+      label: 'Neblina Quântica',
+      description: 'Tons futuristas de lilás e ciano com brilho metálico.',
+      accent: '#a855f7',
+      softAccent: 'rgba(168, 85, 247, 0.26)',
+      previewGradient: 'linear-gradient(135deg, #1a1033 0%, #3a1a5a 100%)',
+      tone: 'dark',
+      previewFontFamily: "'Space Grotesk', 'Inter', 'Segoe UI', sans-serif",
     },
   ]);
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -278,6 +278,372 @@ $hero-theme: mat.define-theme((
   --mdc-linear-progress-track-color: rgba(29, 211, 176, 0.25);
 }
 
+:root[data-theme='radiant-dawn'] {
+  color-scheme: light;
+  --hk-text-primary: #1f2933;
+  --hk-text-secondary: rgba(31, 41, 51, 0.82);
+  --hk-text-muted: rgba(31, 41, 51, 0.64);
+  --hk-surface: rgba(255, 255, 255, 0.94);
+  --hk-surface-elevated: rgba(243, 246, 255, 0.96);
+  --hk-border: rgba(37, 99, 235, 0.16);
+  --hk-accent: #2563eb;
+  --hk-accent-rgb: 37, 99, 235;
+  --hk-accent-soft: rgba(37, 99, 235, 0.16);
+  --hk-accent-strong: #1d4ed8;
+  --hk-accent-strong-rgb: 29, 78, 216;
+  --hk-accent-gradient: linear-gradient(135deg, #93c5fd 0%, #2563eb 100%);
+  --hk-accent-gradient-progress: linear-gradient(90deg, #2563eb 0%, #38bdf8 50%, #f59e0b 100%);
+  --hk-success: #16a34a;
+  --hk-success-rgb: 22, 163, 74;
+  --hk-success-soft: rgba(22, 163, 74, 0.15);
+  --hk-success-border: rgba(var(--hk-success-rgb), 0.24);
+  --hk-warning: #f59e0b;
+  --hk-danger: #dc2626;
+  --hk-font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --hk-heading-font-family: 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
+  --hk-heading-letter-spacing: 0.05em;
+  --hk-body-background-color: #f5f7ff;
+  --hk-body-background-image: radial-gradient(circle at 12% 15%, rgba(37, 99, 235, 0.12), transparent 55%),
+    radial-gradient(circle at 85% 8%, rgba(14, 165, 233, 0.16), transparent 50%),
+    linear-gradient(180deg, #f9fbff 0%, #edf2ff 100%);
+  --hk-shell-background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(236, 243, 255, 0.96) 100%);
+  --hk-toolbar-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  --hk-sidenav-background: rgba(255, 255, 255, 0.92);
+  --hk-sidenav-border: rgba(15, 23, 42, 0.08);
+  --hk-logo-gradient: linear-gradient(135deg, #38bdf8 0%, #2563eb 60%, #f97316 100%);
+  --hk-nav-hover: rgba(37, 99, 235, 0.14);
+  background-color: var(--hk-body-background-color);
+  font-family: var(--hk-font-family);
+
+  --mat-sys-color-primary: var(--hk-accent);
+  --mat-sys-color-on-primary: #ffffff;
+  --mat-sys-color-primary-container: #dbeafe;
+  --mat-sys-color-on-primary-container: #102a78;
+
+  --mat-sys-color-secondary: #0ea5e9;
+  --mat-sys-color-on-secondary: #ffffff;
+  --mat-sys-color-secondary-container: #cffafe;
+  --mat-sys-color-on-secondary-container: #0c4a6e;
+
+  --mat-sys-color-tertiary: #f97316;
+  --mat-sys-color-on-tertiary: #371300;
+  --mat-sys-color-tertiary-container: #ffedd5;
+  --mat-sys-color-on-tertiary-container: #7c2d12;
+
+  --mat-sys-color-error: var(--hk-danger);
+  --mat-sys-color-on-error: #ffffff;
+  --mat-sys-color-error-container: #fee2e2;
+  --mat-sys-color-on-error-container: #7f1d1d;
+
+  --mat-sys-color-surface: #f5f7ff;
+  --mat-sys-color-surface-dim: #e2e8f0;
+  --mat-sys-color-surface-bright: #ffffff;
+  --mat-sys-color-surface-container-lowest: #ffffff;
+  --mat-sys-color-surface-container-low: #f8fafc;
+  --mat-sys-color-surface-container: rgba(255, 255, 255, 0.96);
+  --mat-sys-color-surface-container-high: rgba(241, 245, 255, 0.96);
+  --mat-sys-color-surface-container-highest: rgba(226, 232, 240, 0.96);
+
+  --mat-sys-color-on-surface: var(--hk-text-primary);
+  --mat-sys-color-on-surface-variant: rgba(15, 23, 42, 0.68);
+  --mat-sys-color-outline: rgba(15, 23, 42, 0.18);
+  --mat-sys-color-outline-variant: rgba(15, 23, 42, 0.1);
+  --mat-sys-color-inverse-surface: #1f2937;
+  --mat-sys-color-inverse-on-surface: #f8fafc;
+  --mat-sys-color-inverse-primary: #93c5fd;
+  --mat-sys-color-shadow: rgba(15, 23, 42, 0.12);
+  --mat-sys-color-surface-tint: var(--hk-accent);
+  --mat-sys-elevation-level2: 0 14px 30px rgba(15, 23, 42, 0.12);
+
+  --mat-toolbar-container-background-color: rgba(255, 255, 255, 0.92);
+  --mat-toolbar-container-text-color: var(--hk-text-primary);
+  --mat-toolbar-container-shadow-color: rgba(15, 23, 42, 0.12);
+  --mat-sidenav-container-background-color: rgba(241, 245, 255, 0.6);
+  --mat-sidenav-content-background-color: transparent;
+  --mat-sidenav-container-text-color: var(--hk-text-primary);
+  --mat-list-active-indicator-color: var(--hk-accent);
+  --mat-list-item-label-text-color: var(--hk-text-secondary);
+  --mat-card-background-color: rgba(255, 255, 255, 0.94);
+  --mat-card-title-text-color: var(--hk-text-primary);
+  --mat-card-subtitle-text-color: var(--hk-text-muted);
+  --mat-chip-selected-container-color: var(--hk-accent-soft);
+  --mat-chip-selected-label-text-color: var(--hk-text-primary);
+  --mat-chip-selected-avatar-color: var(--hk-accent);
+  --mat-chip-focus-ring-color: rgba(37, 99, 235, 0.35);
+  --mat-select-panel-background-color: rgba(255, 255, 255, 0.98);
+  --mat-select-enabled-trigger-text-color: var(--hk-text-primary);
+  --mat-option-selected-state-label-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-container-color: rgba(255, 255, 255, 0.85);
+  --mdc-filled-text-field-input-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-hover-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-focus-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-active-indicator-color: rgba(37, 99, 235, 0.45);
+  --mdc-filled-text-field-label-text-color: var(--hk-text-muted);
+  --mdc-filled-text-field-hover-label-text-color: var(--hk-text-secondary);
+  --mdc-filled-text-field-focus-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-text-field-outline-color: rgba(37, 99, 235, 0.35);
+  --mdc-outlined-text-field-focus-outline-color: var(--hk-accent);
+  --mdc-outlined-text-field-hover-outline-color: rgba(37, 99, 235, 0.55);
+  --mdc-protected-button-container-color: rgba(37, 99, 235, 0.14);
+  --mdc-protected-button-label-text-color: var(--hk-accent);
+  --mdc-unelevated-button-container-color: var(--hk-accent);
+  --mdc-unelevated-button-label-text-color: #ffffff;
+  --mdc-unelevated-button-disabled-container-color: rgba(15, 23, 42, 0.1);
+  --mdc-unelevated-button-disabled-label-text-color: rgba(15, 23, 42, 0.35);
+  --mdc-outlined-button-outline-color: rgba(15, 23, 42, 0.18);
+  --mdc-outlined-button-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-button-disabled-outline-color: rgba(15, 23, 42, 0.08);
+  --mdc-outlined-button-disabled-label-text-color: rgba(15, 23, 42, 0.3);
+  --mdc-icon-button-icon-color: var(--hk-text-secondary);
+  --mdc-icon-button-disabled-icon-color: rgba(15, 23, 42, 0.25);
+  --mdc-linear-progress-active-indicator-color: var(--hk-accent);
+  --mdc-linear-progress-track-color: rgba(37, 99, 235, 0.18);
+}
+
+:root[data-theme='ember-forge'] {
+  color-scheme: dark;
+  --hk-text-primary: #fff6f0;
+  --hk-text-secondary: rgba(255, 237, 229, 0.92);
+  --hk-text-muted: rgba(255, 221, 209, 0.72);
+  --hk-surface: rgba(38, 14, 10, 0.88);
+  --hk-surface-elevated: rgba(61, 20, 12, 0.92);
+  --hk-border: rgba(249, 115, 22, 0.18);
+  --hk-accent: #f97316;
+  --hk-accent-rgb: 249, 115, 22;
+  --hk-accent-soft: rgba(249, 115, 22, 0.22);
+  --hk-accent-strong: #fb923c;
+  --hk-accent-strong-rgb: 251, 146, 60;
+  --hk-accent-gradient: linear-gradient(135deg, #b45309 0%, #f97316 100%);
+  --hk-accent-gradient-progress: linear-gradient(90deg, #f97316 0%, #facc15 50%, #ef4444 100%);
+  --hk-success: #facc15;
+  --hk-success-rgb: 250, 204, 21;
+  --hk-success-soft: rgba(250, 204, 21, 0.2);
+  --hk-success-border: rgba(var(--hk-success-rgb), 0.28);
+  --hk-warning: #fbbf24;
+  --hk-danger: #ef4444;
+  --hk-font-family: 'Rubik', 'Inter', 'Segoe UI', sans-serif;
+  --hk-heading-font-family: 'Chakra Petch', 'Rubik', 'Segoe UI', sans-serif;
+  --hk-heading-letter-spacing: 0.08em;
+  --hk-body-background-color: #160806;
+  --hk-body-background-image: radial-gradient(circle at 18% 12%, rgba(249, 115, 22, 0.22), transparent 55%),
+    radial-gradient(circle at 88% 5%, rgba(251, 191, 36, 0.18), transparent 50%),
+    linear-gradient(180deg, rgba(18, 5, 4, 0.96) 0%, rgba(12, 3, 2, 0.96) 100%);
+  --hk-shell-background: linear-gradient(135deg, rgba(56, 16, 8, 0.94) 0%, rgba(24, 6, 3, 0.94) 100%);
+  --hk-toolbar-shadow: 0 14px 36px rgba(8, 2, 1, 0.55);
+  --hk-sidenav-background: rgba(34, 10, 6, 0.94);
+  --hk-sidenav-border: rgba(249, 115, 22, 0.16);
+  --hk-logo-gradient: linear-gradient(135deg, #f97316 0%, #fb923c 45%, #facc15 100%);
+  --hk-nav-hover: rgba(249, 115, 22, 0.18);
+  background-color: var(--hk-body-background-color);
+  font-family: var(--hk-font-family);
+
+  --mat-sys-color-primary: var(--hk-accent);
+  --mat-sys-color-on-primary: #1f0a02;
+  --mat-sys-color-primary-container: rgba(124, 45, 18, 0.92);
+  --mat-sys-color-on-primary-container: #fff0e6;
+
+  --mat-sys-color-secondary: #fb923c;
+  --mat-sys-color-on-secondary: #2c0d02;
+  --mat-sys-color-secondary-container: rgba(97, 33, 10, 0.92);
+  --mat-sys-color-on-secondary-container: #ffe8d5;
+
+  --mat-sys-color-tertiary: #facc15;
+  --mat-sys-color-on-tertiary: #2f2100;
+  --mat-sys-color-tertiary-container: rgba(103, 68, 3, 0.92);
+  --mat-sys-color-on-tertiary-container: #fff7d6;
+
+  --mat-sys-color-error: var(--hk-danger);
+  --mat-sys-color-on-error: #2c0b0b;
+  --mat-sys-color-error-container: rgba(63, 12, 12, 0.92);
+  --mat-sys-color-on-error-container: #fee2e2;
+
+  --mat-sys-color-surface: #160806;
+  --mat-sys-color-surface-dim: #0d0403;
+  --mat-sys-color-surface-bright: #2f120b;
+  --mat-sys-color-surface-container-lowest: #080200;
+  --mat-sys-color-surface-container-low: rgba(27, 9, 6, 0.88);
+  --mat-sys-color-surface-container: rgba(36, 12, 8, 0.92);
+  --mat-sys-color-surface-container-high: rgba(48, 16, 10, 0.94);
+  --mat-sys-color-surface-container-highest: rgba(61, 20, 12, 0.96);
+
+  --mat-sys-color-on-surface: var(--hk-text-primary);
+  --mat-sys-color-on-surface-variant: rgba(255, 214, 198, 0.72);
+  --mat-sys-color-outline: rgba(249, 115, 22, 0.22);
+  --mat-sys-color-outline-variant: rgba(249, 115, 22, 0.16);
+  --mat-sys-color-inverse-surface: #fff5eb;
+  --mat-sys-color-inverse-on-surface: #3f1305;
+  --mat-sys-color-inverse-primary: #fed7aa;
+  --mat-sys-color-shadow: rgba(8, 2, 1, 0.6);
+  --mat-sys-color-surface-tint: var(--hk-accent);
+  --mat-sys-elevation-level2: 0 20px 44px rgba(8, 2, 1, 0.55);
+
+  --mat-toolbar-container-background-color: rgba(27, 9, 6, 0.94);
+  --mat-toolbar-container-text-color: var(--hk-text-primary);
+  --mat-toolbar-container-shadow-color: rgba(8, 2, 1, 0.55);
+  --mat-sidenav-container-background-color: #090301;
+  --mat-sidenav-content-background-color: transparent;
+  --mat-sidenav-container-text-color: var(--hk-text-primary);
+  --mat-list-active-indicator-color: var(--hk-accent);
+  --mat-list-item-label-text-color: var(--hk-text-secondary);
+  --mat-card-background-color: rgba(43, 14, 9, 0.92);
+  --mat-card-title-text-color: var(--hk-text-primary);
+  --mat-card-subtitle-text-color: var(--hk-text-muted);
+  --mat-chip-selected-container-color: var(--hk-accent-soft);
+  --mat-chip-selected-label-text-color: var(--hk-text-primary);
+  --mat-chip-selected-avatar-color: var(--hk-text-primary);
+  --mat-chip-focus-ring-color: rgba(249, 115, 22, 0.35);
+  --mat-select-panel-background-color: rgba(27, 9, 6, 0.98);
+  --mat-select-enabled-trigger-text-color: var(--hk-text-primary);
+  --mat-option-selected-state-label-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-container-color: rgba(24, 8, 6, 0.7);
+  --mdc-filled-text-field-input-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-hover-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-focus-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-active-indicator-color: rgba(249, 115, 22, 0.5);
+  --mdc-filled-text-field-label-text-color: var(--hk-text-muted);
+  --mdc-filled-text-field-hover-label-text-color: var(--hk-text-secondary);
+  --mdc-filled-text-field-focus-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-text-field-outline-color: rgba(249, 115, 22, 0.4);
+  --mdc-outlined-text-field-focus-outline-color: var(--hk-accent);
+  --mdc-outlined-text-field-hover-outline-color: rgba(249, 115, 22, 0.65);
+  --mdc-protected-button-container-color: rgba(249, 115, 22, 0.18);
+  --mdc-protected-button-label-text-color: var(--hk-accent);
+  --mdc-unelevated-button-container-color: var(--hk-accent);
+  --mdc-unelevated-button-label-text-color: #2c0d02;
+  --mdc-unelevated-button-disabled-container-color: rgba(255, 255, 255, 0.08);
+  --mdc-unelevated-button-disabled-label-text-color: rgba(255, 255, 255, 0.36);
+  --mdc-outlined-button-outline-color: rgba(249, 115, 22, 0.4);
+  --mdc-outlined-button-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-button-disabled-outline-color: rgba(255, 255, 255, 0.12);
+  --mdc-outlined-button-disabled-label-text-color: rgba(255, 255, 255, 0.3);
+  --mdc-icon-button-icon-color: var(--hk-text-secondary);
+  --mdc-icon-button-disabled-icon-color: rgba(255, 255, 255, 0.3);
+  --mdc-linear-progress-active-indicator-color: var(--hk-accent);
+  --mdc-linear-progress-track-color: rgba(249, 115, 22, 0.25);
+}
+
+:root[data-theme='quantum-mist'] {
+  color-scheme: dark;
+  --hk-text-primary: #f7f5ff;
+  --hk-text-secondary: rgba(232, 226, 255, 0.9);
+  --hk-text-muted: rgba(210, 202, 243, 0.76);
+  --hk-surface: rgba(24, 12, 45, 0.88);
+  --hk-surface-elevated: rgba(34, 18, 62, 0.92);
+  --hk-border: rgba(168, 85, 247, 0.16);
+  --hk-accent: #a855f7;
+  --hk-accent-rgb: 168, 85, 247;
+  --hk-accent-soft: rgba(168, 85, 247, 0.26);
+  --hk-accent-strong: #38bdf8;
+  --hk-accent-strong-rgb: 56, 189, 248;
+  --hk-accent-gradient: linear-gradient(135deg, #6d28d9 0%, #22d3ee 100%);
+  --hk-accent-gradient-progress: linear-gradient(90deg, #a855f7 0%, #38bdf8 50%, #f472b6 100%);
+  --hk-success: #34d399;
+  --hk-success-rgb: 52, 211, 153;
+  --hk-success-soft: rgba(52, 211, 153, 0.2);
+  --hk-success-border: rgba(var(--hk-success-rgb), 0.32);
+  --hk-warning: #f59e0b;
+  --hk-danger: #fb7185;
+  --hk-font-family: 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
+  --hk-heading-font-family: 'Chakra Petch', 'Space Grotesk', 'Segoe UI', sans-serif;
+  --hk-heading-letter-spacing: 0.07em;
+  --hk-body-background-color: #0d061a;
+  --hk-body-background-image: radial-gradient(circle at 16% 18%, rgba(168, 85, 247, 0.24), transparent 55%),
+    radial-gradient(circle at 78% 4%, rgba(56, 189, 248, 0.2), transparent 50%),
+    linear-gradient(180deg, rgba(8, 5, 18, 0.96) 0%, rgba(5, 3, 12, 0.96) 100%);
+  --hk-shell-background: linear-gradient(135deg, rgba(31, 16, 61, 0.94) 0%, rgba(10, 5, 24, 0.94) 100%);
+  --hk-toolbar-shadow: 0 16px 40px rgba(5, 2, 12, 0.52);
+  --hk-sidenav-background: rgba(17, 9, 34, 0.94);
+  --hk-sidenav-border: rgba(168, 85, 247, 0.16);
+  --hk-logo-gradient: linear-gradient(135deg, #a855f7 0%, #38bdf8 50%, #f472b6 100%);
+  --hk-nav-hover: rgba(168, 85, 247, 0.18);
+  background-color: var(--hk-body-background-color);
+  font-family: var(--hk-font-family);
+
+  --mat-sys-color-primary: var(--hk-accent);
+  --mat-sys-color-on-primary: #23043a;
+  --mat-sys-color-primary-container: rgba(71, 30, 111, 0.92);
+  --mat-sys-color-on-primary-container: #f3e8ff;
+
+  --mat-sys-color-secondary: #38bdf8;
+  --mat-sys-color-on-secondary: #011f28;
+  --mat-sys-color-secondary-container: rgba(16, 58, 82, 0.92);
+  --mat-sys-color-on-secondary-container: #d9f6ff;
+
+  --mat-sys-color-tertiary: #f472b6;
+  --mat-sys-color-on-tertiary: #36081c;
+  --mat-sys-color-tertiary-container: rgba(86, 20, 54, 0.92);
+  --mat-sys-color-on-tertiary-container: #ffd7eb;
+
+  --mat-sys-color-error: var(--hk-danger);
+  --mat-sys-color-on-error: #2c0b0b;
+  --mat-sys-color-error-container: rgba(63, 20, 20, 0.92);
+  --mat-sys-color-on-error-container: #fee2e2;
+
+  --mat-sys-color-surface: #0d061a;
+  --mat-sys-color-surface-dim: #070312;
+  --mat-sys-color-surface-bright: #201138;
+  --mat-sys-color-surface-container-lowest: #05020c;
+  --mat-sys-color-surface-container-low: rgba(18, 10, 36, 0.88);
+  --mat-sys-color-surface-container: rgba(27, 14, 51, 0.92);
+  --mat-sys-color-surface-container-high: rgba(36, 19, 67, 0.94);
+  --mat-sys-color-surface-container-highest: rgba(45, 24, 83, 0.96);
+
+  --mat-sys-color-on-surface: var(--hk-text-primary);
+  --mat-sys-color-on-surface-variant: rgba(210, 202, 243, 0.72);
+  --mat-sys-color-outline: rgba(168, 85, 247, 0.2);
+  --mat-sys-color-outline-variant: rgba(168, 85, 247, 0.14);
+  --mat-sys-color-inverse-surface: #f7f5ff;
+  --mat-sys-color-inverse-on-surface: #281144;
+  --mat-sys-color-inverse-primary: #d8b4fe;
+  --mat-sys-color-shadow: rgba(5, 2, 12, 0.6);
+  --mat-sys-color-surface-tint: var(--hk-accent);
+  --mat-sys-elevation-level2: 0 22px 48px rgba(5, 2, 12, 0.52);
+
+  --mat-toolbar-container-background-color: rgba(18, 10, 36, 0.94);
+  --mat-toolbar-container-text-color: var(--hk-text-primary);
+  --mat-toolbar-container-shadow-color: rgba(5, 2, 12, 0.52);
+  --mat-sidenav-container-background-color: #080312;
+  --mat-sidenav-content-background-color: transparent;
+  --mat-sidenav-container-text-color: var(--hk-text-primary);
+  --mat-list-active-indicator-color: var(--hk-accent);
+  --mat-list-item-label-text-color: var(--hk-text-secondary);
+  --mat-card-background-color: rgba(32, 16, 63, 0.92);
+  --mat-card-title-text-color: var(--hk-text-primary);
+  --mat-card-subtitle-text-color: var(--hk-text-muted);
+  --mat-chip-selected-container-color: var(--hk-accent-soft);
+  --mat-chip-selected-label-text-color: var(--hk-text-primary);
+  --mat-chip-selected-avatar-color: var(--hk-text-primary);
+  --mat-chip-focus-ring-color: rgba(168, 85, 247, 0.38);
+  --mat-select-panel-background-color: rgba(18, 10, 36, 0.98);
+  --mat-select-enabled-trigger-text-color: var(--hk-text-primary);
+  --mat-option-selected-state-label-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-container-color: rgba(20, 11, 39, 0.7);
+  --mdc-filled-text-field-input-text-color: var(--hk-text-primary);
+  --mdc-filled-text-field-hover-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-focus-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-active-indicator-color: rgba(168, 85, 247, 0.5);
+  --mdc-filled-text-field-label-text-color: var(--hk-text-muted);
+  --mdc-filled-text-field-hover-label-text-color: var(--hk-text-secondary);
+  --mdc-filled-text-field-focus-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-text-field-outline-color: rgba(168, 85, 247, 0.4);
+  --mdc-outlined-text-field-focus-outline-color: var(--hk-accent);
+  --mdc-outlined-text-field-hover-outline-color: rgba(168, 85, 247, 0.65);
+  --mdc-protected-button-container-color: rgba(168, 85, 247, 0.22);
+  --mdc-protected-button-label-text-color: var(--hk-accent);
+  --mdc-unelevated-button-container-color: var(--hk-accent);
+  --mdc-unelevated-button-label-text-color: #1f0f35;
+  --mdc-unelevated-button-disabled-container-color: rgba(255, 255, 255, 0.08);
+  --mdc-unelevated-button-disabled-label-text-color: rgba(255, 255, 255, 0.36);
+  --mdc-outlined-button-outline-color: rgba(168, 85, 247, 0.4);
+  --mdc-outlined-button-label-text-color: var(--hk-text-primary);
+  --mdc-outlined-button-disabled-outline-color: rgba(255, 255, 255, 0.12);
+  --mdc-outlined-button-disabled-label-text-color: rgba(255, 255, 255, 0.3);
+  --mdc-icon-button-icon-color: var(--hk-text-secondary);
+  --mdc-icon-button-disabled-icon-color: rgba(255, 255, 255, 0.3);
+  --mdc-linear-progress-active-indicator-color: var(--hk-accent);
+  --mdc-linear-progress-track-color: rgba(168, 85, 247, 0.3);
+}
+
 a {
   color: inherit;
 }


### PR DESCRIPTION
## Summary
- add three new theme presets (Aurora Matinal, Forja em Brasas, Neblina Quântica) to the theme state alongside metadata updates
- extend global styling tokens with dedicated palettes for each new theme, including a light-mode option
- update theme selection documentation and tests to reflect the expanded catalog

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: Chrome binary not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68e06a9663b08333a718455f2b3fa6bd