### PR TITLE
Adjust Aurora Matinal light theme palette

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -280,54 +280,54 @@ $hero-theme: mat.define-theme((
 
 :root[data-theme='radiant-dawn'] {
   color-scheme: light;
-  --hk-text-primary: #1f2933;
-  --hk-text-secondary: rgba(31, 41, 51, 0.82);
-  --hk-text-muted: rgba(31, 41, 51, 0.64);
-  --hk-surface: rgba(255, 255, 255, 0.94);
-  --hk-surface-elevated: rgba(243, 246, 255, 0.96);
-  --hk-border: rgba(37, 99, 235, 0.16);
+  --hk-text-primary: #1d2540;
+  --hk-text-secondary: rgba(29, 37, 64, 0.78);
+  --hk-text-muted: rgba(29, 37, 64, 0.58);
+  --hk-surface: #ffffff;
+  --hk-surface-elevated: #f2f5ff;
+  --hk-border: rgba(17, 24, 39, 0.1);
   --hk-accent: #2563eb;
   --hk-accent-rgb: 37, 99, 235;
-  --hk-accent-soft: rgba(37, 99, 235, 0.16);
+  --hk-accent-soft: rgba(37, 99, 235, 0.12);
   --hk-accent-strong: #1d4ed8;
   --hk-accent-strong-rgb: 29, 78, 216;
-  --hk-accent-gradient: linear-gradient(135deg, #93c5fd 0%, #2563eb 100%);
-  --hk-accent-gradient-progress: linear-gradient(90deg, #2563eb 0%, #38bdf8 50%, #f59e0b 100%);
+  --hk-accent-gradient: linear-gradient(135deg, #f6d365 0%, #fda085 45%, #2563eb 100%);
+  --hk-accent-gradient-progress: linear-gradient(90deg, #2563eb 0%, #38bdf8 50%, #f97316 100%);
   --hk-success: #16a34a;
   --hk-success-rgb: 22, 163, 74;
   --hk-success-soft: rgba(22, 163, 74, 0.15);
-  --hk-success-border: rgba(var(--hk-success-rgb), 0.24);
+  --hk-success-border: rgba(var(--hk-success-rgb), 0.22);
   --hk-warning: #f59e0b;
   --hk-danger: #dc2626;
   --hk-font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --hk-heading-font-family: 'Space Grotesk', 'Inter', 'Segoe UI', sans-serif;
   --hk-heading-letter-spacing: 0.05em;
-  --hk-body-background-color: #f5f7ff;
-  --hk-body-background-image: radial-gradient(circle at 12% 15%, rgba(37, 99, 235, 0.12), transparent 55%),
-    radial-gradient(circle at 85% 8%, rgba(14, 165, 233, 0.16), transparent 50%),
-    linear-gradient(180deg, #f9fbff 0%, #edf2ff 100%);
-  --hk-shell-background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(236, 243, 255, 0.96) 100%);
-  --hk-toolbar-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  --hk-body-background-color: #fefaf4;
+  --hk-body-background-image: radial-gradient(circle at 15% 10%, rgba(253, 224, 171, 0.38), transparent 55%),
+    radial-gradient(circle at 82% 12%, rgba(148, 197, 253, 0.32), transparent 48%),
+    linear-gradient(180deg, #ffffff 0%, #eef2ff 65%, #fef3c7 100%);
+  --hk-shell-background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(243, 246, 255, 0.96) 100%);
+  --hk-toolbar-shadow: 0 10px 28px rgba(15, 23, 42, 0.1);
   --hk-sidenav-background: rgba(255, 255, 255, 0.92);
   --hk-sidenav-border: rgba(15, 23, 42, 0.08);
-  --hk-logo-gradient: linear-gradient(135deg, #38bdf8 0%, #2563eb 60%, #f97316 100%);
-  --hk-nav-hover: rgba(37, 99, 235, 0.14);
+  --hk-logo-gradient: linear-gradient(135deg, #f97316 0%, #fbbf24 35%, #38bdf8 100%);
+  --hk-nav-hover: rgba(37, 99, 235, 0.12);
   background-color: var(--hk-body-background-color);
   font-family: var(--hk-font-family);
 
   --mat-sys-color-primary: var(--hk-accent);
   --mat-sys-color-on-primary: #ffffff;
-  --mat-sys-color-primary-container: #dbeafe;
+  --mat-sys-color-primary-container: #e2e9ff;
   --mat-sys-color-on-primary-container: #102a78;
 
   --mat-sys-color-secondary: #0ea5e9;
   --mat-sys-color-on-secondary: #ffffff;
-  --mat-sys-color-secondary-container: #cffafe;
+  --mat-sys-color-secondary-container: #d9f4ff;
   --mat-sys-color-on-secondary-container: #0c4a6e;
 
   --mat-sys-color-tertiary: #f97316;
   --mat-sys-color-on-tertiary: #371300;
-  --mat-sys-color-tertiary-container: #ffedd5;
+  --mat-sys-color-tertiary-container: #ffe7d6;
   --mat-sys-color-on-tertiary-container: #7c2d12;
 
   --mat-sys-color-error: var(--hk-danger);
@@ -335,69 +335,69 @@ $hero-theme: mat.define-theme((
   --mat-sys-color-error-container: #fee2e2;
   --mat-sys-color-on-error-container: #7f1d1d;
 
-  --mat-sys-color-surface: #f5f7ff;
-  --mat-sys-color-surface-dim: #e2e8f0;
+  --mat-sys-color-surface: #fefaf4;
+  --mat-sys-color-surface-dim: #e7edf8;
   --mat-sys-color-surface-bright: #ffffff;
   --mat-sys-color-surface-container-lowest: #ffffff;
-  --mat-sys-color-surface-container-low: #f8fafc;
+  --mat-sys-color-surface-container-low: #f9fbff;
   --mat-sys-color-surface-container: rgba(255, 255, 255, 0.96);
-  --mat-sys-color-surface-container-high: rgba(241, 245, 255, 0.96);
-  --mat-sys-color-surface-container-highest: rgba(226, 232, 240, 0.96);
+  --mat-sys-color-surface-container-high: rgba(244, 247, 255, 0.96);
+  --mat-sys-color-surface-container-highest: rgba(229, 234, 246, 0.96);
 
   --mat-sys-color-on-surface: var(--hk-text-primary);
-  --mat-sys-color-on-surface-variant: rgba(15, 23, 42, 0.68);
-  --mat-sys-color-outline: rgba(15, 23, 42, 0.18);
-  --mat-sys-color-outline-variant: rgba(15, 23, 42, 0.1);
+  --mat-sys-color-on-surface-variant: rgba(29, 37, 64, 0.64);
+  --mat-sys-color-outline: rgba(17, 24, 39, 0.14);
+  --mat-sys-color-outline-variant: rgba(17, 24, 39, 0.08);
   --mat-sys-color-inverse-surface: #1f2937;
   --mat-sys-color-inverse-on-surface: #f8fafc;
   --mat-sys-color-inverse-primary: #93c5fd;
-  --mat-sys-color-shadow: rgba(15, 23, 42, 0.12);
+  --mat-sys-color-shadow: rgba(15, 23, 42, 0.1);
   --mat-sys-color-surface-tint: var(--hk-accent);
-  --mat-sys-elevation-level2: 0 14px 30px rgba(15, 23, 42, 0.12);
+  --mat-sys-elevation-level2: 0 12px 28px rgba(15, 23, 42, 0.12);
 
   --mat-toolbar-container-background-color: rgba(255, 255, 255, 0.92);
   --mat-toolbar-container-text-color: var(--hk-text-primary);
-  --mat-toolbar-container-shadow-color: rgba(15, 23, 42, 0.12);
-  --mat-sidenav-container-background-color: rgba(241, 245, 255, 0.6);
+  --mat-toolbar-container-shadow-color: rgba(15, 23, 42, 0.1);
+  --mat-sidenav-container-background-color: rgba(248, 250, 255, 0.65);
   --mat-sidenav-content-background-color: transparent;
   --mat-sidenav-container-text-color: var(--hk-text-primary);
   --mat-list-active-indicator-color: var(--hk-accent);
   --mat-list-item-label-text-color: var(--hk-text-secondary);
-  --mat-card-background-color: rgba(255, 255, 255, 0.94);
+  --mat-card-background-color: #ffffff;
   --mat-card-title-text-color: var(--hk-text-primary);
   --mat-card-subtitle-text-color: var(--hk-text-muted);
   --mat-chip-selected-container-color: var(--hk-accent-soft);
   --mat-chip-selected-label-text-color: var(--hk-text-primary);
   --mat-chip-selected-avatar-color: var(--hk-accent);
-  --mat-chip-focus-ring-color: rgba(37, 99, 235, 0.35);
+  --mat-chip-focus-ring-color: rgba(37, 99, 235, 0.3);
   --mat-select-panel-background-color: rgba(255, 255, 255, 0.98);
   --mat-select-enabled-trigger-text-color: var(--hk-text-primary);
   --mat-option-selected-state-label-text-color: var(--hk-text-primary);
-  --mdc-filled-text-field-container-color: rgba(255, 255, 255, 0.85);
+  --mdc-filled-text-field-container-color: rgba(255, 255, 255, 0.9);
   --mdc-filled-text-field-input-text-color: var(--hk-text-primary);
-  --mdc-filled-text-field-hover-active-indicator-color: var(--hk-accent);
+  --mdc-filled-text-field-hover-active-indicator-color: rgba(37, 99, 235, 0.8);
   --mdc-filled-text-field-focus-active-indicator-color: var(--hk-accent);
-  --mdc-filled-text-field-active-indicator-color: rgba(37, 99, 235, 0.45);
+  --mdc-filled-text-field-active-indicator-color: rgba(37, 99, 235, 0.35);
   --mdc-filled-text-field-label-text-color: var(--hk-text-muted);
   --mdc-filled-text-field-hover-label-text-color: var(--hk-text-secondary);
   --mdc-filled-text-field-focus-label-text-color: var(--hk-text-primary);
-  --mdc-outlined-text-field-outline-color: rgba(37, 99, 235, 0.35);
+  --mdc-outlined-text-field-outline-color: rgba(37, 99, 235, 0.28);
   --mdc-outlined-text-field-focus-outline-color: var(--hk-accent);
-  --mdc-outlined-text-field-hover-outline-color: rgba(37, 99, 235, 0.55);
+  --mdc-outlined-text-field-hover-outline-color: rgba(37, 99, 235, 0.48);
   --mdc-protected-button-container-color: rgba(37, 99, 235, 0.14);
   --mdc-protected-button-label-text-color: var(--hk-accent);
   --mdc-unelevated-button-container-color: var(--hk-accent);
   --mdc-unelevated-button-label-text-color: #ffffff;
   --mdc-unelevated-button-disabled-container-color: rgba(15, 23, 42, 0.1);
-  --mdc-unelevated-button-disabled-label-text-color: rgba(15, 23, 42, 0.35);
-  --mdc-outlined-button-outline-color: rgba(15, 23, 42, 0.18);
+  --mdc-unelevated-button-disabled-label-text-color: rgba(15, 23, 42, 0.32);
+  --mdc-outlined-button-outline-color: rgba(17, 24, 39, 0.14);
   --mdc-outlined-button-label-text-color: var(--hk-text-primary);
   --mdc-outlined-button-disabled-outline-color: rgba(15, 23, 42, 0.08);
   --mdc-outlined-button-disabled-label-text-color: rgba(15, 23, 42, 0.3);
   --mdc-icon-button-icon-color: var(--hk-text-secondary);
   --mdc-icon-button-disabled-icon-color: rgba(15, 23, 42, 0.25);
   --mdc-linear-progress-active-indicator-color: var(--hk-accent);
-  --mdc-linear-progress-track-color: rgba(37, 99, 235, 0.18);
+  --mdc-linear-progress-track-color: rgba(37, 99, 235, 0.16);
 }
 
 :root[data-theme='ember-forge'] {


### PR DESCRIPTION
## Summary
- rebalance Aurora Matinal text and surface tokens to improve readability in the light theme
- refresh gradient accents and Material color tokens to deliver a softer sunrise aesthetic

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e06dda6270833388f062b33a119352