### PR TITLE
fix: restore theme adaptive profile styling

### DIFF
--- a/src/app/features/profile/pages/profile.page.scss
+++ b/src/app/features/profile/pages/profile.page.scss
@@ -4,13 +4,38 @@
 }
 
 .profile {
+  --profile-text-primary: var(--hk-text-primary);
+  --profile-text-secondary: var(--hk-text-secondary);
+  --profile-text-muted: var(--hk-text-muted);
+  --profile-border: rgba(255, 255, 255, 0.08);
+  --profile-border-strong: rgba(255, 255, 255, 0.18);
+  --profile-surface: rgba(13, 16, 34, 0.8);
+  --profile-surface-soft: rgba(255, 255, 255, 0.06);
+  --profile-surface-subtle: rgba(255, 255, 255, 0.03);
+  --profile-progress-track: rgba(124, 92, 255, 0.16);
+  --profile-shadow: 0 28px 60px rgba(10, 12, 28, 0.45);
+
   display: grid;
   gap: 2rem;
   padding: clamp(1rem, 3vw, 2.5rem);
-  background: rgba(13, 16, 34, 0.8);
+  background: var(--profile-surface);
   border-radius: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 28px 60px rgba(10, 12, 28, 0.45);
+  border: 1px solid var(--profile-border);
+  box-shadow: var(--profile-shadow);
+  color: var(--profile-text-primary);
+}
+
+:host-context([data-theme='radiant-dawn']) .profile {
+  --profile-text-primary: #0f172a;
+  --profile-text-secondary: #1f2937;
+  --profile-text-muted: #64748b;
+  --profile-border: rgba(15, 23, 42, 0.08);
+  --profile-border-strong: rgba(15, 23, 42, 0.16);
+  --profile-surface: #ffffff;
+  --profile-surface-soft: rgba(226, 232, 240, 0.65);
+  --profile-surface-subtle: rgba(226, 232, 240, 0.45);
+  --profile-progress-track: rgba(15, 23, 42, 0.1);
+  --profile-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
 }
 
 .profile__header {
@@ -28,7 +53,7 @@
 
 .profile__header p {
   margin: 0.35rem 0 0;
-  color: var(--hk-text-muted);
+  color: var(--profile-text-muted);
   max-width: 48ch;
 }
 
@@ -59,7 +84,7 @@
 
 .profile__xp p {
   margin: 0;
-  color: var(--hk-text-secondary);
+  color: var(--profile-text-secondary);
 }
 
 .profile__theme {
@@ -78,7 +103,7 @@
 
 .profile__theme > header p {
   margin: 0;
-  color: var(--hk-text-muted);
+  color: var(--profile-text-muted);
 }
 
 .theme-options {
@@ -116,8 +141,8 @@
   gap: 0.75rem;
   padding: 1.1rem 1.25rem;
   border-radius: 1.15rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--profile-border);
+  background: var(--profile-surface-subtle);
   transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
   cursor: pointer;
   position: relative;
@@ -126,12 +151,12 @@
 
 .theme-option__card:hover {
   transform: translateY(-2px);
-  border-color: rgba(255, 255, 255, 0.18);
+  border-color: var(--profile-border-strong);
 }
 
 .theme-option__card--active {
   border-color: var(--theme-accent);
-  box-shadow: 0 18px 36px rgba(10, 12, 28, 0.4), 0 0 0 1px var(--theme-accent);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18), 0 0 0 1px var(--theme-accent);
 }
 
 .theme-option__input:focus-visible + .theme-option__card {
@@ -146,7 +171,7 @@
   height: 3rem;
   border-radius: 0.85rem;
   background-image: var(--theme-preview);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--profile-border);
 }
 
 .theme-option__content {
@@ -161,7 +186,7 @@
 }
 
 .theme-option__description {
-  color: var(--hk-text-muted);
+  color: var(--profile-text-muted);
   font-size: 0.95rem;
 }
 
@@ -180,7 +205,7 @@
   position: relative;
   height: 0.85rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--profile-progress-track);
   overflow: hidden;
 }
 
@@ -210,7 +235,7 @@
 .profile__achievements > header p,
 .profile__loot > header p {
   margin: 0;
-  color: var(--hk-text-muted);
+  color: var(--profile-text-muted);
 }
 
 .profile__achievements ul,
@@ -227,8 +252,8 @@
   gap: 0.85rem;
   padding: 1.25rem;
   border-radius: 1.25rem;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--profile-surface-soft);
+  border: 1px solid var(--profile-border);
 }
 
 .achievement-card > header {
@@ -257,7 +282,7 @@
 
 .achievement-card__description {
   margin: 0.25rem 0 0;
-  color: var(--hk-text-muted);
+  color: var(--profile-text-muted);
   font-size: 0.95rem;
 }
 
@@ -265,7 +290,7 @@
   position: relative;
   height: 0.6rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--profile-progress-track);
   overflow: hidden;
 }
 
@@ -278,7 +303,7 @@
 .achievement-card__value {
   justify-self: end;
   font-size: 0.9rem;
-  color: var(--hk-text-muted);
+  color: var(--profile-text-muted);
 }
 
 .profile__loot li {
@@ -288,8 +313,8 @@
   gap: 1rem;
   padding: 1rem 1.25rem;
   border-radius: 1.1rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--profile-border);
+  background: var(--profile-surface-subtle);
   font-size: 1rem;
 }
 
@@ -307,7 +332,7 @@
 }
 
 .loot-card__quantity {
-  color: var(--hk-text-muted);
+  color: var(--profile-text-muted);
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- restore the profile surface defaults to the dark theme values while keeping local tokens for reuse
- add a radiant-dawn override so the section adopts the white background, borders, and tracks when the light theme is active

## Testing
- not run (styles only)


------
https://chatgpt.com/codex/tasks/task_e_68e158c74fa083339cea9f6f0b94ced3