### PR TITLE
Fix theme propagation to document surfaces

### DIFF
--- a/src/app/core/state/theme.state.spec.ts
+++ b/src/app/core/state/theme.state.spec.ts
@@ -1,26 +1,47 @@
 import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 
+import { OverlayContainer } from '@angular/cdk/overlay';
+
 import { ThemeState } from './theme.state';
 
 describe('ThemeState', () => {
   let state: ThemeState;
   let documentRef: Document;
+  let overlayContainerElement: HTMLElement;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    overlayContainerElement = document.createElement('div');
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: OverlayContainer,
+          useValue: {
+            getContainerElement: () => overlayContainerElement,
+            ngOnDestroy: () => {},
+          } as OverlayContainer,
+        },
+      ],
+    });
     documentRef = TestBed.inject(DOCUMENT);
     documentRef.documentElement.dataset['theme'] = '';
+    documentRef.body.dataset['theme'] = '';
+    overlayContainerElement.dataset['theme'] = '';
     state = TestBed.inject(ThemeState);
   });
 
   afterEach(() => {
     documentRef.documentElement.dataset['theme'] = '';
+    documentRef.body.dataset['theme'] = '';
+    overlayContainerElement.dataset['theme'] = '';
   });
 
   it('should expose the default theme and apply it to the document', () => {
     expect(state.currentTheme()).toBe('stellar-night');
     expect(documentRef.documentElement.dataset['theme']).toBe('stellar-night');
+    expect(documentRef.body.dataset['theme']).toBe('stellar-night');
+    expect(overlayContainerElement.dataset['theme']).toBe('stellar-night');
   });
 
   it('should expose the available themes with their tone metadata', () => {
@@ -35,6 +56,8 @@ describe('ThemeState', () => {
 
     expect(state.currentTheme()).toBe('radiant-dawn');
     expect(documentRef.documentElement.dataset['theme']).toBe('radiant-dawn');
+    expect(documentRef.body.dataset['theme']).toBe('radiant-dawn');
+    expect(overlayContainerElement.dataset['theme']).toBe('radiant-dawn');
   });
 
   it('should ignore unknown theme identifiers', () => {

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -1,5 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import { inject, Injectable, signal } from '@angular/core';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 export type ThemeId =
   | 'stellar-night'
@@ -22,6 +23,7 @@ export interface ThemeOption {
 @Injectable({ providedIn: 'root' })
 export class ThemeState {
   private readonly documentRef = inject(DOCUMENT);
+  private readonly overlayContainer = inject(OverlayContainer, { optional: true });
 
   private readonly _themes = signal<readonly ThemeOption[]>([
     {
@@ -101,12 +103,26 @@ export class ThemeState {
   }
 
   private applyTheme(themeId: ThemeId): void {
-    const rootElement = this.documentRef?.documentElement;
+    const documentRef = this.documentRef;
 
-    if (!rootElement) {
+    if (!documentRef) {
       return;
     }
 
-    rootElement.dataset['theme'] = themeId;
+    const rootElement = documentRef.documentElement;
+    const bodyElement = documentRef.body;
+    const overlayElement = this.overlayContainer?.getContainerElement();
+
+    if (rootElement) {
+      rootElement.dataset['theme'] = themeId;
+    }
+
+    if (bodyElement) {
+      bodyElement.dataset['theme'] = themeId;
+    }
+
+    if (overlayElement) {
+      overlayElement.dataset['theme'] = themeId;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure the selected theme id is written to the document element, body and overlay container so all surfaces adopt the correct palette
- cover the new propagation points in ThemeState unit tests via a mocked overlay container

## Testing
- npm run test -- --watch=false --include src/app/core/state/theme.state.spec.ts *(fails: missing Chrome binary in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15d8976348333bf7ee01684f0f3a9