### PR TITLE
fix: align board stats chips with theme

### DIFF
--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -41,15 +41,15 @@
 
           <div class="board__stats">
             <mat-chip-set>
-              <mat-chip variant="outlined">
+              <mat-chip class="board__stats-chip" color="primary" selected>
                 <mat-icon matChipAvatar fontSet="material-symbols-rounded">task_alt</mat-icon>
                 Histórias concluídas: {{ summary().completedStories }}
               </mat-chip>
-              <mat-chip variant="outlined">
+              <mat-chip class="board__stats-chip" color="primary" selected>
                 <mat-icon matChipAvatar fontSet="material-symbols-rounded">hub</mat-icon>
                 Features ativas: {{ summary().activeFeatures }}
               </mat-chip>
-              <mat-chip variant="outlined">
+              <mat-chip class="board__stats-chip" color="primary" selected>
                 <mat-icon matChipAvatar fontSet="material-symbols-rounded">monitoring</mat-icon>
                 Throughput semanal: {{ summary().weeklyThroughput }}
               </mat-chip>

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -144,6 +144,33 @@
   gap: 0.45rem;
 }
 
+.board__stats-chip {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  --mdc-chip-container-color: var(--hk-accent-soft);
+  --mdc-chip-elevated-container-color: var(--hk-accent-soft);
+  --mdc-chip-label-text-color: var(--hk-text-primary);
+  --mdc-chip-selected-label-text-color: var(--hk-text-primary);
+  --mdc-chip-with-icon-icon-color: var(--hk-text-primary);
+  --mdc-chip-outline-color: rgba(var(--hk-accent-strong-rgb), 0.35);
+  --mdc-chip-focus-outline-color: rgba(var(--hk-accent-strong-rgb), 0.55);
+  --mdc-chip-hover-state-layer-color: rgba(var(--hk-accent-rgb), 0.3);
+  --mdc-chip-focus-state-layer-color: rgba(var(--hk-accent-rgb), 0.35);
+  background: var(--hk-accent-soft);
+  color: var(--hk-text-primary);
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.board__stats-chip mat-icon {
+  color: currentColor;
+}
+
+.board__stats-chip:focus-visible,
+.board__stats-chip:hover {
+  background: rgba(var(--hk-accent-rgb), 0.22);
+  box-shadow: 0 0 0 1px rgba(var(--hk-accent-strong-rgb), 0.5);
+}
+
 
 .board__toolbar {
   display: flex;


### PR DESCRIPTION
## Summary
- mark the board summary metric chips as selected so they inherit themed colors
- restyle the metric chips to use the accent soft background and hover/focus feedback tied to the active palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16001bea48333bf3b57208216a79b