### PR TITLE
Fix theme-aware styling for sprints and board customizer

### DIFF
--- a/src/app/features/board-customizer/pages/board-customizer.page.scss
+++ b/src/app/features/board-customizer/pages/board-customizer.page.scss
@@ -7,15 +7,16 @@
   display: grid;
   gap: 2rem;
   padding: clamp(1rem, 3vw, 2.5rem);
-  background: rgba(13, 16, 34, 0.85);
+  background: var(--hk-surface);
   border-radius: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  box-shadow: 0 24px 56px rgba(10, 12, 28, 0.45);
+  border: 1px solid var(--hk-border);
+  box-shadow: var(--mat-sys-elevation-level2, 0 24px 56px rgba(10, 12, 28, 0.45));
 }
 
 .board-customizer__header h1 {
   margin: 0;
   font-size: clamp(1.7rem, 3vw, 2.2rem);
+  color: var(--hk-text-primary);
 }
 
 .board-customizer__header p {
@@ -61,20 +62,21 @@
   gap: 1rem;
   padding: 1.25rem;
   border-radius: 1.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.05);
-  transition: border-color 0.2s ease, background-color 0.2s ease;
+  border: 1px solid var(--hk-border);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 92%, transparent);
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .status-item:hover,
 .status-item:focus-within {
-  border-color: rgba(var(--hk-accent-rgb), 0.45);
-  background: rgba(var(--hk-accent-rgb), 0.12);
+  border-color: color-mix(in srgb, var(--hk-accent) 45%, var(--hk-border));
+  background: color-mix(in srgb, var(--hk-accent-soft) 65%, var(--hk-surface));
+  box-shadow: var(--mat-sys-elevation-level2, 0 20px 40px rgba(10, 12, 28, 0.35));
 }
 
 .status-item.cdk-drag-preview {
-  box-shadow: 0 24px 48px rgba(10, 12, 28, 0.6);
-  border-color: rgba(var(--hk-accent-rgb), 0.65);
+  box-shadow: var(--mat-sys-elevation-level2, 0 24px 48px rgba(10, 12, 28, 0.6));
+  border-color: color-mix(in srgb, var(--hk-accent) 65%, var(--hk-border));
 }
 
 .status-item.cdk-drag-placeholder {
@@ -98,8 +100,8 @@
   width: 3rem;
   height: 3rem;
   border-radius: 1rem;
-  background: rgba(var(--hk-accent-rgb), 0.2);
-  color: #f8fafc;
+  background: color-mix(in srgb, var(--hk-accent-soft) 70%, var(--hk-surface));
+  color: var(--hk-text-primary);
   font-size: 1.8rem;
 }
 
@@ -141,17 +143,17 @@
   gap: 0.35rem;
   padding: 0.4rem 0.75rem;
   border-radius: 999px;
-  background: rgba(var(--hk-accent-rgb), 0.18);
-  border: 1px solid rgba(var(--hk-accent-rgb), 0.35);
+  background: color-mix(in srgb, var(--hk-accent-soft) 65%, var(--hk-surface));
+  border: 1px solid color-mix(in srgb, var(--hk-accent) 45%, var(--hk-border));
   font-size: 0.85rem;
   font-weight: 600;
-  color: #e2e8f0;
+  color: var(--hk-text-primary);
 }
 
 .status-item__snack--inactive {
-  background: rgba(248, 113, 113, 0.15);
-  border-color: rgba(248, 113, 113, 0.35);
-  color: #fecaca;
+  background: color-mix(in srgb, var(--hk-danger) 18%, var(--hk-surface));
+  border-color: color-mix(in srgb, var(--hk-danger) 45%, var(--hk-border));
+  color: color-mix(in srgb, var(--hk-danger) 55%, var(--hk-text-primary));
 }
 
 .status-item__actions {
@@ -169,8 +171,8 @@
   width: 2.25rem;
   height: 2.25rem;
   border-radius: 0.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(17, 24, 39, 0.7);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 75%, transparent);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 88%, transparent);
   color: inherit;
   cursor: grab;
   transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
@@ -183,8 +185,8 @@
 .status-item__drag-handle:hover,
 .status-item__drag-handle:focus-visible {
   transform: translateY(-1px);
-  border-color: rgba(var(--hk-accent-rgb), 0.6);
-  background: rgba(var(--hk-accent-rgb), 0.25);
+  border-color: color-mix(in srgb, var(--hk-accent) 45%, var(--hk-border));
+  background: color-mix(in srgb, var(--hk-accent-soft) 60%, var(--hk-surface));
 }
 
 .status-item__toggle {
@@ -208,9 +210,9 @@
   gap: 0.35rem;
   padding: 0.6rem 0.9rem;
   border-radius: 0.9rem;
-  border: 1px solid rgba(var(--hk-accent-rgb), 0.45);
-  background: rgba(var(--hk-accent-rgb), 0.15);
-  color: #ede9fe;
+  border: 1px solid color-mix(in srgb, var(--hk-accent) 45%, var(--hk-border));
+  background: color-mix(in srgb, var(--hk-accent-soft) 60%, var(--hk-surface));
+  color: var(--hk-text-primary);
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, filter 0.2s ease, border-color 0.2s ease;
@@ -220,7 +222,7 @@
 .status-item__edit:focus-visible {
   transform: translateY(-1px);
   filter: brightness(1.05);
-  border-color: rgba(var(--hk-accent-rgb), 0.75);
+  border-color: color-mix(in srgb, var(--hk-accent) 65%, var(--hk-border));
 }
 
 .status-form {
@@ -248,8 +250,8 @@
 .status-form__field select {
   padding: 0.75rem 1rem;
   border-radius: 0.9rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(8, 8, 18, 0.5);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 80%, transparent);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 90%, transparent);
   color: inherit;
   font: inherit;
 }
@@ -276,8 +278,8 @@
   gap: 0.75rem;
   padding: 0.5rem;
   border-radius: 0.85rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(8, 8, 18, 0.5);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 75%, transparent);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 88%, transparent);
 }
 
 .status-form__icon-select span {
@@ -287,8 +289,8 @@
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 0.75rem;
-  background: rgba(var(--hk-accent-rgb), 0.2);
-  color: #f8fafc;
+  background: color-mix(in srgb, var(--hk-accent-soft) 70%, var(--hk-surface));
+  color: var(--hk-text-primary);
   font-size: 1.6rem;
 }
 
@@ -313,6 +315,7 @@
   color: #ffffff;
   cursor: pointer;
   transition: transform 0.2s ease, filter 0.2s ease;
+  box-shadow: var(--mat-sys-elevation-level2, 0 14px 30px rgba(var(--hk-accent-strong-rgb, 79, 70, 229), 0.35));
 }
 
 .status-form__actions button:disabled {
@@ -379,9 +382,9 @@
   gap: 0.35rem;
   padding: 0.6rem 0.9rem;
   border-radius: 0.9rem;
-  border: 1px solid rgba(248, 113, 113, 0.55);
-  background: rgba(248, 113, 113, 0.15);
-  color: #fecaca;
+  border: 1px solid color-mix(in srgb, var(--hk-danger) 45%, var(--hk-border));
+  background: color-mix(in srgb, var(--hk-danger) 18%, var(--hk-surface));
+  color: color-mix(in srgb, var(--hk-danger) 55%, var(--hk-text-primary));
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, filter 0.2s ease, border-color 0.2s ease;
@@ -391,5 +394,5 @@
 .status-item__delete:focus-visible {
   transform: translateY(-1px);
   filter: brightness(1.05);
-  border-color: rgba(248, 113, 113, 0.8);
+  border-color: color-mix(in srgb, var(--hk-danger) 65%, var(--hk-border));
 }

--- a/src/app/features/board/components/create-story-modal/create-story-modal.component.scss
+++ b/src/app/features/board/components/create-story-modal/create-story-modal.component.scss
@@ -13,7 +13,7 @@
 .create-story-modal__backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(4, 6, 20, 0.75);
+  background: color-mix(in srgb, #000 35%, var(--hk-body-background-color, #0f0c29) 65%);
   backdrop-filter: blur(8px);
 }
 
@@ -23,9 +23,9 @@
   max-height: calc(100vh - 2 * var(--create-story-modal-padding));
   overflow: auto;
   border-radius: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(145deg, rgba(24, 22, 54, 0.95), rgba(16, 18, 42, 0.95));
-  box-shadow: 0 30px 80px rgba(8, 9, 29, 0.65);
+  border: 1px solid var(--hk-border);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 96%, transparent);
+  box-shadow: var(--mat-sys-elevation-level2, 0 30px 80px rgba(8, 9, 29, 0.65));
 }
 
 .create-story-modal__form {
@@ -55,7 +55,7 @@
 
 .create-story-modal__close {
   border: none;
-  background: rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 90%, transparent);
   border-radius: 999px;
   width: 2.5rem;
   height: 2.5rem;
@@ -68,7 +68,7 @@
 
 .create-story-modal__close:hover,
 .create-story-modal__close:focus-visible {
-  background: rgba(255, 255, 255, 0.14);
+  background: color-mix(in srgb, var(--hk-accent-soft) 55%, var(--hk-surface));
   transform: scale(1.05);
 }
 
@@ -93,8 +93,8 @@
   width: 100%;
   padding: 0.75rem 1rem;
   border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(14, 16, 38, 0.75);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 75%, transparent);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 90%, transparent);
   color: inherit;
   font: inherit;
 }
@@ -106,12 +106,12 @@
 }
 
 .create-story-modal__field small {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--hk-text-muted);
   font-size: 0.8rem;
 }
 
 .create-story-modal__field small.ng-star-inserted {
-  color: #fbbf24;
+  color: var(--hk-warning);
 }
 
 .create-story-modal__tasks {
@@ -144,8 +144,8 @@
   gap: 0.75rem;
   padding: 1rem;
   border-radius: 1.25rem;
-  border: 1px solid rgba(var(--hk-accent-rgb), 0.2);
-  background: rgba(var(--hk-accent-rgb), 0.08);
+  border: 1px solid color-mix(in srgb, var(--hk-accent) 35%, var(--hk-border));
+  background: color-mix(in srgb, var(--hk-accent-soft) 55%, var(--hk-surface));
 }
 
 .create-story-modal__task label {
@@ -154,15 +154,15 @@
 }
 
 .create-story-modal__task small {
-  color: #fbbf24;
+  color: var(--hk-warning);
   font-size: 0.8rem;
 }
 
 .create-story-modal__task input[type='text'] {
   padding: 0.7rem 1rem;
   border-radius: 0.9rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(10, 12, 28, 0.75);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 75%, transparent);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 88%, transparent);
   color: inherit;
 }
 
@@ -192,8 +192,8 @@
 
 .create-story-modal__task-actions button {
   border: none;
-  background: rgba(248, 113, 113, 0.18);
-  color: #fca5a5;
+  background: color-mix(in srgb, var(--hk-danger) 20%, var(--hk-surface));
+  color: color-mix(in srgb, var(--hk-danger) 60%, var(--hk-text-primary));
   border-radius: 999px;
   width: 2.25rem;
   height: 2.25rem;
@@ -205,7 +205,7 @@
 
 .create-story-modal__task-actions button:hover,
 .create-story-modal__task-actions button:focus-visible {
-  background: rgba(248, 113, 113, 0.3);
+  background: color-mix(in srgb, var(--hk-danger) 35%, var(--hk-surface));
   transform: scale(1.05);
 }
 
@@ -213,7 +213,7 @@
   margin: 0;
   padding: 1rem;
   border-radius: 1rem;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
+  border: 1px dashed color-mix(in srgb, var(--hk-border) 75%, transparent);
   color: var(--hk-text-muted);
   font-size: 0.9rem;
   text-align: center;
@@ -253,15 +253,15 @@
 .create-story-modal__secondary {
   padding: 0.85rem 1.4rem;
   border-radius: 0.9rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--hk-border) 75%, transparent);
+  background: color-mix(in srgb, var(--hk-surface) 92%, transparent);
   color: var(--hk-text-primary);
   cursor: pointer;
 }
 
 .create-story-modal__secondary:hover,
 .create-story-modal__secondary:focus-visible {
-  background: rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--hk-accent-soft) 55%, var(--hk-surface));
 }
 
 .create-story-modal__primary {

--- a/src/app/features/sprints/pages/sprints.page.scss
+++ b/src/app/features/sprints/pages/sprints.page.scss
@@ -14,11 +14,11 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  background: var(--hk-surface);
+  background: var(--hk-surface-elevated);
   border: 1px solid var(--hk-border);
   border-radius: 1.5rem;
   padding: clamp(1.5rem, 3vw, 2.5rem);
-  box-shadow: 0 25px 50px -12px rgba(15, 12, 41, 0.4);
+  box-shadow: var(--mat-sys-elevation-level2, 0 25px 50px -12px rgba(15, 12, 41, 0.4));
 }
 
 .sprints__hero-heading {
@@ -91,11 +91,11 @@
 .sprint {
   display: grid;
   gap: 1.5rem;
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: var(--hk-surface);
+  border: 1px solid var(--hk-border);
   border-radius: 1.5rem;
   padding: clamp(1.5rem, 2.6vw, 2.25rem);
-  box-shadow: 0 20px 45px -18px rgba(12, 10, 36, 0.55);
+  box-shadow: var(--mat-sys-elevation-level2, 0 20px 45px -18px rgba(12, 10, 36, 0.55));
 }
 
 .sprint__header {
@@ -138,7 +138,8 @@
 }
 
 .sprint__meta > div {
-  background: rgba(255, 255, 255, 0.05);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 65%, transparent);
   border-radius: 1rem;
   padding: 0.85rem 1rem;
 }
@@ -161,8 +162,8 @@
   margin: 0;
   padding: 0.85rem 1rem;
   border-radius: 1rem;
-  background: rgba(var(--hk-accent-rgb), 0.18);
-  border: 1px solid rgba(var(--hk-accent-rgb), 0.35);
+  background: color-mix(in srgb, var(--hk-accent-soft) 70%, var(--hk-surface));
+  border: 1px solid color-mix(in srgb, var(--hk-accent) 45%, var(--hk-border));
   color: var(--hk-text-primary);
   font-weight: 500;
 }
@@ -176,12 +177,13 @@
 }
 
 .sprint-story {
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: var(--hk-surface-elevated);
+  border: 1px solid var(--hk-border);
   border-radius: 1.25rem;
   padding: 1.1rem 1.35rem;
   display: grid;
   gap: 0.9rem;
+  box-shadow: var(--mat-sys-elevation-level2, 0 18px 36px rgba(12, 10, 36, 0.4));
 }
 
 .sprint-story__header {
@@ -219,9 +221,10 @@
   gap: 0.35rem;
   padding: 0.3rem 0.75rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--status-color, var(--hk-accent)) 22%, var(--hk-surface));
   position: relative;
   color: var(--hk-text-primary);
+  border: 1px solid color-mix(in srgb, var(--status-color, var(--hk-accent)) 35%, var(--hk-border));
 }
 
 .sprint-story__status::before {
@@ -247,22 +250,22 @@
   gap: 0.65rem;
   padding: 0.55rem 0.75rem;
   border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--hk-surface-elevated) 88%, transparent);
+  border: 1px solid var(--hk-border);
   transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
 .sprint-story__task:hover,
 .sprint-story__task:focus-visible {
-  border-color: rgba(var(--hk-accent-rgb), 0.5);
-  background: rgba(var(--hk-accent-rgb), 0.12);
+  border-color: color-mix(in srgb, var(--hk-accent) 45%, var(--hk-border));
+  background: color-mix(in srgb, var(--hk-accent-soft) 65%, var(--hk-surface));
 }
 
 .sprint-story__task-indicator {
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 50%;
-  border: 2px solid rgba(148, 163, 184, 0.6);
+  border: 2px solid color-mix(in srgb, var(--hk-text-muted) 65%, transparent);
   background: transparent;
   transition: background-color 0.2s ease, border-color 0.2s ease;
 }
@@ -277,13 +280,14 @@
 }
 
 .sprints__empty {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px dashed rgba(148, 163, 184, 0.35);
+  background: var(--hk-surface);
+  border: 1px dashed color-mix(in srgb, var(--hk-border) 75%, transparent);
   border-radius: 1.5rem;
   padding: clamp(1.75rem, 3vw, 2.5rem);
   text-align: center;
   display: grid;
   gap: 0.75rem;
+  box-shadow: var(--mat-sys-elevation-level2, 0 18px 36px rgba(12, 10, 36, 0.35));
 }
 
 .sprints__empty > h2 {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -652,6 +652,35 @@ a {
   box-sizing: border-box;
 }
 
+.mdc-evolution-chip__cell--primary {
+  background-color: var(--hk-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--hk-accent) 45%, var(--hk-border));
+  color: var(--hk-text-primary);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.mdc-evolution-chip--selected .mdc-evolution-chip__cell--primary {
+  background-color: color-mix(in srgb, var(--hk-accent) 40%, var(--hk-surface));
+  border-color: color-mix(in srgb, var(--hk-accent) 65%, var(--hk-border));
+  color: var(--hk-text-primary);
+}
+
+.mdc-evolution-chip__cell--primary .mdc-evolution-chip__action--primary,
+.mdc-evolution-chip__action--primary {
+  color: var(--hk-text-primary);
+}
+
+.mdc-evolution-chip__cell--primary:hover,
+.mdc-evolution-chip__cell--primary:focus-within {
+  background-color: color-mix(in srgb, var(--hk-accent-soft) 80%, var(--hk-surface));
+  border-color: color-mix(in srgb, var(--hk-accent) 55%, var(--hk-border));
+}
+
+.mdc-evolution-chip__cell--primary .mdc-evolution-chip__ripple::before,
+.mdc-evolution-chip__cell--primary .mdc-evolution-chip__ripple::after {
+  background-color: color-mix(in srgb, var(--hk-accent) 45%, transparent);
+}
+
 ::-webkit-scrollbar {
   width: 0.6rem;
   height: 0.6rem;


### PR DESCRIPTION
## Summary
- align sprint overview and story cards with theme-driven surfaces and accents
- refresh board customizer panels, controls, and chips to pull colors from the active theme
- theme the new story modal backgrounds and chip primitives so overlays stay consistent

## Testing
- not run (scss-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e163420b5c8333ae571fa14b37aaf3