### PR TITLE
refactor: load theme metadata from json manifests

### DIFF
--- a/src/app/core/state/theme-manifest.d.ts
+++ b/src/app/core/state/theme-manifest.d.ts
@@ -1,0 +1,15 @@
+interface ThemeManifest {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly accent: string;
+  readonly softAccent: string;
+  readonly previewGradient: string;
+  readonly tone: 'dark' | 'light';
+  readonly previewFontFamily: string;
+}
+
+declare module '*.json' {
+  const value: ThemeManifest;
+  export default value;
+}

--- a/src/app/core/state/theme.config.ts
+++ b/src/app/core/state/theme.config.ts
@@ -1,0 +1,57 @@
+export type ThemeTone = 'dark' | 'light';
+
+export interface ThemeOption {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly accent: string;
+  readonly softAccent: string;
+  readonly previewGradient: string;
+  readonly tone: ThemeTone;
+  readonly previewFontFamily: string;
+}
+
+import stellarNightManifest from './themes/stellar-night.json';
+import auroraCrestManifest from './themes/aurora-crest.json';
+import radiantDawnManifest from './themes/radiant-dawn.json';
+import emberForgeManifest from './themes/ember-forge.json';
+import quantumMistManifest from './themes/quantum-mist.json';
+
+type ThemeManifest = Omit<ThemeOption, 'tone'> & { readonly tone: string };
+
+const isThemeTone = (value: string): value is ThemeTone => value === 'dark' || value === 'light';
+
+const manifestToThemeOption = (manifest: ThemeManifest): ThemeOption => {
+  if (!isThemeTone(manifest.tone)) {
+    throw new Error(`Invalid tone "${manifest.tone}" provided by theme manifest "${manifest.id}".`);
+  }
+
+  return {
+    ...manifest,
+    tone: manifest.tone,
+  } as ThemeOption;
+};
+
+const themeOptions = [
+  manifestToThemeOption(stellarNightManifest as ThemeManifest),
+  manifestToThemeOption(auroraCrestManifest as ThemeManifest),
+  manifestToThemeOption(radiantDawnManifest as ThemeManifest),
+  manifestToThemeOption(emberForgeManifest as ThemeManifest),
+  manifestToThemeOption(quantumMistManifest as ThemeManifest),
+] as const satisfies readonly ThemeOption[];
+
+export type ThemeId = (typeof themeOptions)[number]['id'];
+
+export interface ThemeConfiguration<TOptions extends readonly ThemeOption[] = readonly ThemeOption[]> {
+  readonly defaultThemeId: TOptions[number]['id'];
+  readonly options: TOptions;
+}
+
+const staticThemeConfiguration = {
+  defaultThemeId: themeOptions[0].id,
+  options: themeOptions,
+} satisfies ThemeConfiguration<typeof themeOptions>;
+
+export const STATIC_THEME_CONFIGURATION = staticThemeConfiguration;
+export const DEFAULT_THEME_ID: ThemeId = staticThemeConfiguration.defaultThemeId;
+export const STATIC_THEME_OPTIONS: readonly ThemeOption[] = staticThemeConfiguration.options;

--- a/src/app/core/state/theme.state.spec.ts
+++ b/src/app/core/state/theme.state.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { OverlayContainer } from '@angular/cdk/overlay';
 
-import { ThemeState } from './theme.state';
+import { DEFAULT_THEME_ID, ThemeState } from './theme.state';
 
 describe('ThemeState', () => {
   let state: ThemeState;
@@ -38,10 +38,10 @@ describe('ThemeState', () => {
   });
 
   it('should expose the default theme and apply it to the document', () => {
-    expect(state.currentTheme()).toBe('stellar-night');
-    expect(documentRef.documentElement.dataset['theme']).toBe('stellar-night');
-    expect(documentRef.body.dataset['theme']).toBe('stellar-night');
-    expect(overlayContainerElement.dataset['theme']).toBe('stellar-night');
+    expect(state.currentTheme()).toBe(DEFAULT_THEME_ID);
+    expect(documentRef.documentElement.dataset['theme']).toBe(DEFAULT_THEME_ID);
+    expect(documentRef.body.dataset['theme']).toBe(DEFAULT_THEME_ID);
+    expect(overlayContainerElement.dataset['theme']).toBe(DEFAULT_THEME_ID);
   });
 
   it('should expose the available themes with their tone metadata', () => {

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -2,83 +2,21 @@ import { DOCUMENT } from '@angular/common';
 import { inject, Injectable, signal } from '@angular/core';
 import { OverlayContainer } from '@angular/cdk/overlay';
 
-export type ThemeId =
-  | 'stellar-night'
-  | 'aurora-crest'
-  | 'radiant-dawn'
-  | 'ember-forge'
-  | 'quantum-mist';
-
-export interface ThemeOption {
-  readonly id: ThemeId;
-  readonly label: string;
-  readonly description: string;
-  readonly accent: string;
-  readonly softAccent: string;
-  readonly previewGradient: string;
-  readonly tone: 'dark' | 'light';
-  readonly previewFontFamily: string;
-}
+import {
+  DEFAULT_THEME_ID,
+  STATIC_THEME_OPTIONS,
+  type ThemeId,
+  type ThemeOption,
+} from './theme.config';
 
 @Injectable({ providedIn: 'root' })
 export class ThemeState {
   private readonly documentRef = inject(DOCUMENT);
   private readonly overlayContainer = inject(OverlayContainer, { optional: true });
 
-  private readonly _themes = signal<readonly ThemeOption[]>([
-    {
-      id: 'stellar-night',
-      label: 'Noite Estelar',
-      description: 'Tema original com tons profundos e acento violeta.',
-      accent: '#7c5cff',
-      softAccent: 'rgba(124, 92, 255, 0.28)',
-      previewGradient: 'linear-gradient(135deg, #1b1933 0%, #433978 100%)',
-      tone: 'dark',
-      previewFontFamily: "'Chakra Petch', 'Inter', 'Segoe UI', sans-serif",
-    },
-    {
-      id: 'aurora-crest',
-      label: 'Aurora Boreal',
-      description: 'Mistura esmeralda e azul para uma interface energizante.',
-      accent: '#1dd3b0',
-      softAccent: 'rgba(29, 211, 176, 0.25)',
-      previewGradient: 'linear-gradient(135deg, #012a4a 0%, #036666 100%)',
-      tone: 'dark',
-      previewFontFamily: "'Space Grotesk', 'Rubik', 'Segoe UI', sans-serif",
-    },
-    {
-      id: 'radiant-dawn',
-      label: 'Aurora Matinal',
-      description: 'Tema claro com foco em clareza e contrastes azulados.',
-      accent: '#2563eb',
-      softAccent: 'rgba(37, 99, 235, 0.18)',
-      previewGradient: 'linear-gradient(135deg, #f1f5ff 0%, #cfe1ff 100%)',
-      tone: 'light',
-      previewFontFamily: "'Inter', 'Segoe UI', sans-serif",
-    },
-    {
-      id: 'ember-forge',
-      label: 'Forja em Brasas',
-      description: 'Paleta vibrante inspirada em brasas e metais aquecidos.',
-      accent: '#f97316',
-      softAccent: 'rgba(249, 115, 22, 0.22)',
-      previewGradient: 'linear-gradient(135deg, #2d1b18 0%, #7c2d12 100%)',
-      tone: 'dark',
-      previewFontFamily: "'Rubik', 'Inter', 'Segoe UI', sans-serif",
-    },
-    {
-      id: 'quantum-mist',
-      label: 'Neblina Quântica',
-      description: 'Tons futuristas de lilás e ciano com brilho metálico.',
-      accent: '#a855f7',
-      softAccent: 'rgba(168, 85, 247, 0.26)',
-      previewGradient: 'linear-gradient(135deg, #1a1033 0%, #3a1a5a 100%)',
-      tone: 'dark',
-      previewFontFamily: "'Space Grotesk', 'Inter', 'Segoe UI', sans-serif",
-    },
-  ]);
+  private readonly _themes = signal<readonly ThemeOption[]>(STATIC_THEME_OPTIONS);
 
-  private readonly _currentTheme = signal<ThemeId>('stellar-night');
+  private readonly _currentTheme = signal<ThemeId>(DEFAULT_THEME_ID);
 
   readonly themes = this._themes.asReadonly();
   readonly currentTheme = this._currentTheme.asReadonly();
@@ -126,3 +64,6 @@ export class ThemeState {
     }
   }
 }
+
+export { DEFAULT_THEME_ID } from './theme.config';
+export type { ThemeId, ThemeOption, ThemeTone } from './theme.config';

--- a/src/app/core/state/themes/aurora-crest.json
+++ b/src/app/core/state/themes/aurora-crest.json
@@ -1,0 +1,10 @@
+{
+  "id": "aurora-crest",
+  "label": "Aurora Boreal",
+  "description": "Mistura esmeralda e azul para uma interface energizante.",
+  "accent": "#1dd3b0",
+  "softAccent": "rgba(29, 211, 176, 0.25)",
+  "previewGradient": "linear-gradient(135deg, #012a4a 0%, #036666 100%)",
+  "tone": "dark",
+  "previewFontFamily": "'Space Grotesk', 'Rubik', 'Segoe UI', sans-serif"
+}

--- a/src/app/core/state/themes/ember-forge.json
+++ b/src/app/core/state/themes/ember-forge.json
@@ -1,0 +1,10 @@
+{
+  "id": "ember-forge",
+  "label": "Forja em Brasas",
+  "description": "Paleta vibrante inspirada em brasas e metais aquecidos.",
+  "accent": "#f97316",
+  "softAccent": "rgba(249, 115, 22, 0.22)",
+  "previewGradient": "linear-gradient(135deg, #2d1b18 0%, #7c2d12 100%)",
+  "tone": "dark",
+  "previewFontFamily": "'Rubik', 'Inter', 'Segoe UI', sans-serif"
+}

--- a/src/app/core/state/themes/quantum-mist.json
+++ b/src/app/core/state/themes/quantum-mist.json
@@ -1,0 +1,10 @@
+{
+  "id": "quantum-mist",
+  "label": "Neblina Quântica",
+  "description": "Tons futuristas de lilás e ciano com brilho metálico.",
+  "accent": "#a855f7",
+  "softAccent": "rgba(168, 85, 247, 0.26)",
+  "previewGradient": "linear-gradient(135deg, #1a1033 0%, #3a1a5a 100%)",
+  "tone": "dark",
+  "previewFontFamily": "'Space Grotesk', 'Inter', 'Segoe UI', sans-serif"
+}

--- a/src/app/core/state/themes/radiant-dawn.json
+++ b/src/app/core/state/themes/radiant-dawn.json
@@ -1,0 +1,10 @@
+{
+  "id": "radiant-dawn",
+  "label": "Aurora Matinal",
+  "description": "Tema claro com foco em clareza e contrastes azulados.",
+  "accent": "#2563eb",
+  "softAccent": "rgba(37, 99, 235, 0.18)",
+  "previewGradient": "linear-gradient(135deg, #f1f5ff 0%, #cfe1ff 100%)",
+  "tone": "light",
+  "previewFontFamily": "'Inter', 'Segoe UI', sans-serif"
+}

--- a/src/app/core/state/themes/stellar-night.json
+++ b/src/app/core/state/themes/stellar-night.json
@@ -1,0 +1,10 @@
+{
+  "id": "stellar-night",
+  "label": "Noite Estelar",
+  "description": "Tema original com tons profundos e acento violeta.",
+  "accent": "#7c5cff",
+  "softAccent": "rgba(124, 92, 255, 0.28)",
+  "previewGradient": "linear-gradient(135deg, #1b1933 0%, #433978 100%)",
+  "tone": "dark",
+  "previewFontFamily": "'Chakra Petch', 'Inter', 'Segoe UI', sans-serif"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,
+    "allowArbitraryExtensions": true,
+    "resolveJsonModule": true,
     "target": "ES2022",
     "module": "ES2022",
     "baseUrl": "./src",


### PR DESCRIPTION
## Summary
- add JSON manifest files for each built-in theme to allow backend-sourced overrides later
- import and validate theme manifests in the theme configuration to supply the state layer
- enable JSON module resolution in TypeScript for the new manifest imports

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless --progress=false *(fails: ChromeHeadless binary not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e183bfeaf08333b539d3fe8fd6c71c