### PR TITLE
feat: aplicar tokens dinâmicos de perfil nos temas

### DIFF
--- a/src/app/core/state/theme.config.ts
+++ b/src/app/core/state/theme.config.ts
@@ -1,5 +1,18 @@
 export type ThemeTone = 'dark' | 'light';
 
+export interface ThemeProfileTokens {
+  readonly textPrimary: string;
+  readonly textSecondary: string;
+  readonly textMuted: string;
+  readonly border: string;
+  readonly borderStrong: string;
+  readonly surface: string;
+  readonly surfaceSoft: string;
+  readonly surfaceSubtle: string;
+  readonly progressTrack: string;
+  readonly shadow: string;
+}
+
 export interface ThemeOption {
   readonly id: string;
   readonly label: string;
@@ -9,40 +22,64 @@ export interface ThemeOption {
   readonly previewGradient: string;
   readonly tone: ThemeTone;
   readonly previewFontFamily: string;
+  readonly profile?: ThemeProfileTokens;
 }
 
-import stellarNightManifest from './themes/stellar-night.json';
-import auroraCrestManifest from './themes/aurora-crest.json';
-import radiantDawnManifest from './themes/radiant-dawn.json';
-import celestialTidesManifest from './themes/celestial-tides.json';
-import emberForgeManifest from './themes/ember-forge.json';
-import quantumMistManifest from './themes/quantum-mist.json';
+type ThemeManifest = Omit<ThemeOption, 'tone' | 'profile'> & {
+  readonly tone: string;
+  readonly isDefault?: boolean;
+  readonly profile?: ThemeProfileTokens;
+};
 
-type ThemeManifest = Omit<ThemeOption, 'tone'> & { readonly tone: string };
+const themeManifestModules = import.meta.glob<ThemeManifest>('./themes/*.json', {
+  eager: true,
+  import: 'default',
+});
+
+const themeManifests = Object.values(themeManifestModules);
+
+if (themeManifests.length === 0) {
+  throw new Error('No theme manifests were found. Provide at least one theme manifest.');
+}
 
 const isThemeTone = (value: string): value is ThemeTone => value === 'dark' || value === 'light';
 
 const manifestToThemeOption = (manifest: ThemeManifest): ThemeOption => {
-  if (!isThemeTone(manifest.tone)) {
-    throw new Error(`Invalid tone "${manifest.tone}" provided by theme manifest "${manifest.id}".`);
+  const { tone, isDefault: _isDefault, profile, ...optionFields } = manifest;
+
+  if (!isThemeTone(tone)) {
+    throw new Error(`Invalid tone "${tone}" provided by theme manifest "${manifest.id}".`);
   }
 
   return {
-    ...manifest,
-    tone: manifest.tone,
-  } as ThemeOption;
+    ...optionFields,
+    tone,
+    profile: profile ? Object.freeze({ ...profile }) : undefined,
+  } satisfies ThemeOption;
 };
 
-const themeOptions = [
-  manifestToThemeOption(stellarNightManifest as ThemeManifest),
-  manifestToThemeOption(auroraCrestManifest as ThemeManifest),
-  manifestToThemeOption(radiantDawnManifest as ThemeManifest),
-  manifestToThemeOption(celestialTidesManifest as ThemeManifest),
-  manifestToThemeOption(emberForgeManifest as ThemeManifest),
-  manifestToThemeOption(quantumMistManifest as ThemeManifest),
-] as const satisfies readonly ThemeOption[];
+const defaultThemeManifest =
+  themeManifests.find((manifest) => manifest.isDefault === true) ??
+  themeManifests.find((manifest) => manifest.id === 'stellar-night') ??
+  themeManifests[0];
 
-export type ThemeId = (typeof themeOptions)[number]['id'];
+const sortedThemeManifests = themeManifests
+  .slice()
+  .sort((first, second) => {
+    if (first.id === defaultThemeManifest.id) {
+      return -1;
+    }
+
+    if (second.id === defaultThemeManifest.id) {
+      return 1;
+    }
+
+    return first.label.localeCompare(second.label, 'pt-BR', { sensitivity: 'base' });
+  });
+
+const themeOptions = Object.freeze(sortedThemeManifests.map(manifestToThemeOption)) as readonly ThemeOption[];
+
+export type ThemeId = ThemeOption['id'];
 
 export interface ThemeConfiguration<TOptions extends readonly ThemeOption[] = readonly ThemeOption[]> {
   readonly defaultThemeId: TOptions[number]['id'];

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -7,7 +7,21 @@ import {
   STATIC_THEME_OPTIONS,
   type ThemeId,
   type ThemeOption,
+  type ThemeProfileTokens,
 } from './theme.config';
+
+const PROFILE_TOKEN_TO_CSS_VARIABLE: ReadonlyArray<readonly [keyof ThemeProfileTokens, string]> = [
+  ['textPrimary', '--hk-profile-text-primary'],
+  ['textSecondary', '--hk-profile-text-secondary'],
+  ['textMuted', '--hk-profile-text-muted'],
+  ['border', '--hk-profile-border'],
+  ['borderStrong', '--hk-profile-border-strong'],
+  ['surface', '--hk-profile-surface'],
+  ['surfaceSoft', '--hk-profile-surface-soft'],
+  ['surfaceSubtle', '--hk-profile-surface-subtle'],
+  ['progressTrack', '--hk-profile-progress-track'],
+  ['shadow', '--hk-profile-shadow'],
+];
 
 @Injectable({ providedIn: 'root' })
 export class ThemeState {
@@ -50,9 +64,12 @@ export class ThemeState {
     const rootElement = documentRef.documentElement;
     const bodyElement = documentRef.body;
     const overlayElement = this.overlayContainer?.getContainerElement();
+    const theme = this._themes().find((option) => option.id === themeId);
+    const profileTokens = theme?.profile;
 
     if (rootElement) {
       rootElement.dataset['theme'] = themeId;
+      this.applyProfileTokens(rootElement, profileTokens);
     }
 
     if (bodyElement) {
@@ -63,7 +80,22 @@ export class ThemeState {
       overlayElement.dataset['theme'] = themeId;
     }
   }
+
+  private applyProfileTokens(
+    target: HTMLElement,
+    profileTokens: ThemeProfileTokens | undefined,
+  ): void {
+    for (const [tokenKey, cssVariable] of PROFILE_TOKEN_TO_CSS_VARIABLE) {
+      const value = profileTokens?.[tokenKey];
+
+      if (value) {
+        target.style.setProperty(cssVariable, value);
+      } else {
+        target.style.removeProperty(cssVariable);
+      }
+    }
+  }
 }
 
 export { DEFAULT_THEME_ID } from './theme.config';
-export type { ThemeId, ThemeOption, ThemeTone } from './theme.config';
+export type { ThemeId, ThemeOption, ThemeTone, ThemeProfileTokens } from './theme.config';

--- a/src/app/core/state/themes/aurora-crest.json
+++ b/src/app/core/state/themes/aurora-crest.json
@@ -6,5 +6,17 @@
   "softAccent": "rgba(29, 211, 176, 0.25)",
   "previewGradient": "linear-gradient(135deg, #012a4a 0%, #036666 100%)",
   "tone": "dark",
-  "previewFontFamily": "'Space Grotesk', 'Rubik', 'Segoe UI', sans-serif"
+  "previewFontFamily": "'Space Grotesk', 'Rubik', 'Segoe UI', sans-serif",
+  "profile": {
+    "textPrimary": "var(--hk-text-primary)",
+    "textSecondary": "var(--hk-text-secondary)",
+    "textMuted": "var(--hk-text-muted)",
+    "border": "rgba(255, 255, 255, 0.08)",
+    "borderStrong": "rgba(255, 255, 255, 0.18)",
+    "surface": "rgba(13, 16, 34, 0.8)",
+    "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+    "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+    "progressTrack": "rgba(124, 92, 255, 0.16)",
+    "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+  }
 }

--- a/src/app/core/state/themes/celestial-tides.json
+++ b/src/app/core/state/themes/celestial-tides.json
@@ -6,5 +6,17 @@
   "softAccent": "rgba(20, 184, 166, 0.18)",
   "previewGradient": "linear-gradient(135deg, #d1fae5 0%, #ecfeff 100%)",
   "tone": "light",
-  "previewFontFamily": "'Inter', 'Segoe UI', sans-serif"
+  "previewFontFamily": "'Inter', 'Segoe UI', sans-serif",
+  "profile": {
+    "textPrimary": "#0f172a",
+    "textSecondary": "#1f2937",
+    "textMuted": "#64748b",
+    "border": "rgba(15, 118, 110, 0.12)",
+    "borderStrong": "rgba(15, 118, 110, 0.22)",
+    "surface": "#ffffff",
+    "surfaceSoft": "rgba(207, 250, 254, 0.65)",
+    "surfaceSubtle": "rgba(207, 250, 254, 0.45)",
+    "progressTrack": "rgba(20, 184, 166, 0.2)",
+    "shadow": "0 24px 48px rgba(15, 118, 110, 0.15)"
+  }
 }

--- a/src/app/core/state/themes/ember-forge.json
+++ b/src/app/core/state/themes/ember-forge.json
@@ -6,5 +6,17 @@
   "softAccent": "rgba(249, 115, 22, 0.22)",
   "previewGradient": "linear-gradient(135deg, #2d1b18 0%, #7c2d12 100%)",
   "tone": "dark",
-  "previewFontFamily": "'Rubik', 'Inter', 'Segoe UI', sans-serif"
+  "previewFontFamily": "'Rubik', 'Inter', 'Segoe UI', sans-serif",
+  "profile": {
+    "textPrimary": "var(--hk-text-primary)",
+    "textSecondary": "var(--hk-text-secondary)",
+    "textMuted": "var(--hk-text-muted)",
+    "border": "rgba(255, 255, 255, 0.08)",
+    "borderStrong": "rgba(255, 255, 255, 0.18)",
+    "surface": "rgba(13, 16, 34, 0.8)",
+    "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+    "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+    "progressTrack": "rgba(124, 92, 255, 0.16)",
+    "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+  }
 }

--- a/src/app/core/state/themes/quantum-mist.json
+++ b/src/app/core/state/themes/quantum-mist.json
@@ -6,5 +6,17 @@
   "softAccent": "rgba(168, 85, 247, 0.26)",
   "previewGradient": "linear-gradient(135deg, #1a1033 0%, #3a1a5a 100%)",
   "tone": "dark",
-  "previewFontFamily": "'Space Grotesk', 'Inter', 'Segoe UI', sans-serif"
+  "previewFontFamily": "'Space Grotesk', 'Inter', 'Segoe UI', sans-serif",
+  "profile": {
+    "textPrimary": "var(--hk-text-primary)",
+    "textSecondary": "var(--hk-text-secondary)",
+    "textMuted": "var(--hk-text-muted)",
+    "border": "rgba(255, 255, 255, 0.08)",
+    "borderStrong": "rgba(255, 255, 255, 0.18)",
+    "surface": "rgba(13, 16, 34, 0.8)",
+    "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+    "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+    "progressTrack": "rgba(124, 92, 255, 0.16)",
+    "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+  }
 }

--- a/src/app/core/state/themes/radiant-dawn.json
+++ b/src/app/core/state/themes/radiant-dawn.json
@@ -6,5 +6,17 @@
   "softAccent": "rgba(37, 99, 235, 0.18)",
   "previewGradient": "linear-gradient(135deg, #f1f5ff 0%, #cfe1ff 100%)",
   "tone": "light",
-  "previewFontFamily": "'Inter', 'Segoe UI', sans-serif"
+  "previewFontFamily": "'Inter', 'Segoe UI', sans-serif",
+  "profile": {
+    "textPrimary": "#0f172a",
+    "textSecondary": "#1f2937",
+    "textMuted": "#64748b",
+    "border": "rgba(15, 23, 42, 0.08)",
+    "borderStrong": "rgba(15, 23, 42, 0.16)",
+    "surface": "#ffffff",
+    "surfaceSoft": "rgba(226, 232, 240, 0.65)",
+    "surfaceSubtle": "rgba(226, 232, 240, 0.45)",
+    "progressTrack": "rgba(15, 23, 42, 0.1)",
+    "shadow": "0 24px 48px rgba(15, 23, 42, 0.12)"
+  }
 }

--- a/src/app/core/state/themes/stellar-night.json
+++ b/src/app/core/state/themes/stellar-night.json
@@ -6,5 +6,17 @@
   "softAccent": "rgba(124, 92, 255, 0.28)",
   "previewGradient": "linear-gradient(135deg, #1b1933 0%, #433978 100%)",
   "tone": "dark",
-  "previewFontFamily": "'Chakra Petch', 'Inter', 'Segoe UI', sans-serif"
+  "previewFontFamily": "'Chakra Petch', 'Inter', 'Segoe UI', sans-serif",
+  "profile": {
+    "textPrimary": "var(--hk-text-primary)",
+    "textSecondary": "var(--hk-text-secondary)",
+    "textMuted": "var(--hk-text-muted)",
+    "border": "rgba(255, 255, 255, 0.08)",
+    "borderStrong": "rgba(255, 255, 255, 0.18)",
+    "surface": "rgba(13, 16, 34, 0.8)",
+    "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+    "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+    "progressTrack": "rgba(124, 92, 255, 0.16)",
+    "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+  }
 }

--- a/src/app/features/profile/pages/profile.page.scss
+++ b/src/app/features/profile/pages/profile.page.scss
@@ -4,16 +4,16 @@
 }
 
 .profile {
-  --profile-text-primary: var(--hk-text-primary);
-  --profile-text-secondary: var(--hk-text-secondary);
-  --profile-text-muted: var(--hk-text-muted);
-  --profile-border: rgba(255, 255, 255, 0.08);
-  --profile-border-strong: rgba(255, 255, 255, 0.18);
-  --profile-surface: rgba(13, 16, 34, 0.8);
-  --profile-surface-soft: rgba(255, 255, 255, 0.06);
-  --profile-surface-subtle: rgba(255, 255, 255, 0.03);
-  --profile-progress-track: rgba(124, 92, 255, 0.16);
-  --profile-shadow: 0 28px 60px rgba(10, 12, 28, 0.45);
+  --profile-text-primary: var(--hk-profile-text-primary, var(--hk-text-primary));
+  --profile-text-secondary: var(--hk-profile-text-secondary, var(--hk-text-secondary));
+  --profile-text-muted: var(--hk-profile-text-muted, var(--hk-text-muted));
+  --profile-border: var(--hk-profile-border, rgba(255, 255, 255, 0.08));
+  --profile-border-strong: var(--hk-profile-border-strong, rgba(255, 255, 255, 0.18));
+  --profile-surface: var(--hk-profile-surface, rgba(13, 16, 34, 0.8));
+  --profile-surface-soft: var(--hk-profile-surface-soft, rgba(255, 255, 255, 0.06));
+  --profile-surface-subtle: var(--hk-profile-surface-subtle, rgba(255, 255, 255, 0.03));
+  --profile-progress-track: var(--hk-profile-progress-track, rgba(124, 92, 255, 0.16));
+  --profile-shadow: var(--hk-profile-shadow, 0 28px 60px rgba(10, 12, 28, 0.45));
 
   display: grid;
   gap: 2rem;
@@ -23,32 +23,6 @@
   border: 1px solid var(--profile-border);
   box-shadow: var(--profile-shadow);
   color: var(--profile-text-primary);
-}
-
-:host-context([data-theme='radiant-dawn']) .profile {
-  --profile-text-primary: #0f172a;
-  --profile-text-secondary: #1f2937;
-  --profile-text-muted: #64748b;
-  --profile-border: rgba(15, 23, 42, 0.08);
-  --profile-border-strong: rgba(15, 23, 42, 0.16);
-  --profile-surface: #ffffff;
-  --profile-surface-soft: rgba(226, 232, 240, 0.65);
-  --profile-surface-subtle: rgba(226, 232, 240, 0.45);
-  --profile-progress-track: rgba(15, 23, 42, 0.1);
-  --profile-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
-}
-
-:host-context([data-theme='celestial-tides']) .profile {
-  --profile-text-primary: #0f172a;
-  --profile-text-secondary: #1f2937;
-  --profile-text-muted: #64748b;
-  --profile-border: rgba(15, 118, 110, 0.12);
-  --profile-border-strong: rgba(15, 118, 110, 0.22);
-  --profile-surface: #ffffff;
-  --profile-surface-soft: rgba(207, 250, 254, 0.65);
-  --profile-surface-subtle: rgba(207, 250, 254, 0.45);
-  --profile-progress-track: rgba(20, 184, 166, 0.2);
-  --profile-shadow: 0 24px 48px rgba(15, 118, 110, 0.15);
 }
 
 .profile__header {

--- a/src/types/import-meta.d.ts
+++ b/src/types/import-meta.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Minimal type augmentation for the Angular esbuild builder glob import helper.
+ * Supports eager loading of JSON manifests via `import.meta.glob`.
+ */
+declare interface ImportMeta {
+  glob<T = unknown>(
+    pattern: string,
+    options: {
+      readonly eager: true;
+      readonly import: 'default';
+    }
+  ): Record<string, T>;
+}


### PR DESCRIPTION
## Summary
- add profile token schema to each theme manifest and expose it through the static configuration
- apply the manifest-provided profile CSS variables whenever the user alternates the theme
- update the profile page styles to consume the injected CSS variables instead of static host-context overrides

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e18cd50ae483338849989407915ef4