### PR TITLE
fix: ensure theme manifests load in production

### DIFF
--- a/src/app/core/state/theme.config.ts
+++ b/src/app/core/state/theme.config.ts
@@ -1,3 +1,10 @@
+import auroraCrestManifest from './themes/aurora-crest.json';
+import celestialTidesManifest from './themes/celestial-tides.json';
+import emberForgeManifest from './themes/ember-forge.json';
+import quantumMistManifest from './themes/quantum-mist.json';
+import radiantDawnManifest from './themes/radiant-dawn.json';
+import stellarNightManifest from './themes/stellar-night.json';
+
 export type ThemeTone = 'dark' | 'light';
 
 export interface ThemeProfileTokens {
@@ -31,12 +38,14 @@ type ThemeManifest = Omit<ThemeOption, 'tone' | 'profile'> & {
   readonly profile?: ThemeProfileTokens;
 };
 
-const themeManifestModules = import.meta.glob<ThemeManifest>('./themes/*.json', {
-  eager: true,
-  import: 'default',
-});
-
-const themeManifests = Object.values(themeManifestModules);
+const themeManifests = Object.freeze([
+  auroraCrestManifest,
+  celestialTidesManifest,
+  emberForgeManifest,
+  quantumMistManifest,
+  radiantDawnManifest,
+  stellarNightManifest,
+]) as readonly ThemeManifest[];
 
 if (themeManifests.length === 0) {
   throw new Error('No theme manifests were found. Provide at least one theme manifest.');


### PR DESCRIPTION
## Summary
- load theme manifests using static imports to guarantee they are bundled for runtime use

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1903e1cd0833388059f4aaa7a4e66