### PR TITLE
refactor: dynamically load theme manifests

### DIFF
--- a/src/app/core/state/theme.config.ts
+++ b/src/app/core/state/theme.config.ts
@@ -1,10 +1,3 @@
-import auroraCrestManifest from './themes/aurora-crest.json';
-import celestialTidesManifest from './themes/celestial-tides.json';
-import emberForgeManifest from './themes/ember-forge.json';
-import quantumMistManifest from './themes/quantum-mist.json';
-import radiantDawnManifest from './themes/radiant-dawn.json';
-import stellarNightManifest from './themes/stellar-night.json';
-
 export type ThemeTone = 'dark' | 'light';
 
 export interface ThemeProfileTokens {
@@ -38,14 +31,12 @@ type ThemeManifest = Omit<ThemeOption, 'tone' | 'profile'> & {
   readonly profile?: ThemeProfileTokens;
 };
 
-const themeManifests = Object.freeze([
-  auroraCrestManifest,
-  celestialTidesManifest,
-  emberForgeManifest,
-  quantumMistManifest,
-  radiantDawnManifest,
-  stellarNightManifest,
-]) as readonly ThemeManifest[];
+const manifestModules = import.meta.glob<ThemeManifest>('./themes/*.json', {
+  eager: true,
+  import: 'default',
+});
+
+const themeManifests = Object.freeze(Object.values(manifestModules)) as readonly ThemeManifest[];
 
 if (themeManifests.length === 0) {
   throw new Error('No theme manifests were found. Provide at least one theme manifest.');


### PR DESCRIPTION
## Summary
- load theme manifests from the themes directory using `import.meta.glob` so new JSON files are auto-discovered
- preserve existing validation and option sorting logic for the resolved manifests

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e19467f93883339e74ca2ef9763db4