### PR TITLE
feat: add royal manuscript medieval theme

### DIFF
--- a/src/app/core/state/theme.config.ts
+++ b/src/app/core/state/theme.config.ts
@@ -3,6 +3,7 @@ import celestialTidesManifest from './themes/celestial-tides.json';
 import emberForgeManifest from './themes/ember-forge.json';
 import quantumMistManifest from './themes/quantum-mist.json';
 import radiantDawnManifest from './themes/radiant-dawn.json';
+import royalManuscriptManifest from './themes/royal-manuscript.json';
 import stellarNightManifest from './themes/stellar-night.json';
 
 export type ThemeTone = 'dark' | 'light';
@@ -44,6 +45,7 @@ const themeManifests = Object.freeze([
   emberForgeManifest,
   quantumMistManifest,
   radiantDawnManifest,
+  royalManuscriptManifest,
   stellarNightManifest,
 ]) as readonly ThemeManifest[];
 

--- a/src/app/core/state/themes/royal-manuscript.json
+++ b/src/app/core/state/themes/royal-manuscript.json
@@ -1,0 +1,22 @@
+{
+  "id": "royal-manuscript",
+  "label": "Manuscrito Real",
+  "description": "Tema medieval com dourado envelhecido e textura de pergaminho.",
+  "accent": "#c8a24b",
+  "softAccent": "rgba(200, 162, 75, 0.28)",
+  "previewGradient": "linear-gradient(135deg, #2b1d12 0%, #8f6b34 50%, #f0d7a1 100%)",
+  "tone": "dark",
+  "previewFontFamily": "'Great Vibes', 'Cinzel Decorative', 'Segoe Script', 'Lucida Handwriting', cursive",
+  "profile": {
+    "textPrimary": "#f4ecde",
+    "textSecondary": "rgba(244, 236, 222, 0.72)",
+    "textMuted": "rgba(244, 236, 222, 0.56)",
+    "border": "rgba(240, 215, 161, 0.18)",
+    "borderStrong": "rgba(240, 215, 161, 0.32)",
+    "surface": "rgba(38, 27, 18, 0.86)",
+    "surfaceSoft": "rgba(64, 45, 28, 0.6)",
+    "surfaceSubtle": "rgba(64, 45, 28, 0.4)",
+    "progressTrack": "rgba(200, 162, 75, 0.24)",
+    "shadow": "0 32px 60px rgba(15, 9, 4, 0.55)"
+  }
+}


### PR DESCRIPTION
## Summary
- add a medieval-inspired Royal Manuscript theme manifest with cursive typography
- register the new theme in the static configuration so it becomes available in the UI

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e287a45dd08333a542886c6c43dbe1