### PR TITLE
Add theme API mock and integrate service loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "start:api": "json-server --watch server/db.json --port 3000 --host 0.0.0.0"
   },
   "private": true,
   "dependencies": {

--- a/server/db.json
+++ b/server/db.json
@@ -1,0 +1,268 @@
+{
+  "themes": [
+    {
+      "id": "aurora-crest",
+      "label": "Aurora Boreal",
+      "description": "Mistura esmeralda e azul para uma interface energizante.",
+      "accent": "#1dd3b0",
+      "softAccent": "rgba(29, 211, 176, 0.25)",
+      "previewGradient": "linear-gradient(135deg, #012a4a 0%, #036666 100%)",
+      "tone": "dark",
+      "previewFontFamily": "'Space Grotesk', 'Rubik', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "var(--hk-text-primary)",
+        "textSecondary": "var(--hk-text-secondary)",
+        "textMuted": "var(--hk-text-muted)",
+        "border": "rgba(255, 255, 255, 0.08)",
+        "borderStrong": "rgba(255, 255, 255, 0.18)",
+        "surface": "rgba(13, 16, 34, 0.8)",
+        "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+        "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+        "progressTrack": "rgba(124, 92, 255, 0.16)",
+        "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+      }
+    },
+    {
+      "id": "celestial-tides",
+      "label": "Maré Celestial",
+      "description": "Tema claro inspirado em tons aquáticos e jade luminoso.",
+      "accent": "#14b8a6",
+      "softAccent": "rgba(20, 184, 166, 0.18)",
+      "previewGradient": "linear-gradient(135deg, #d1fae5 0%, #ecfeff 100%)",
+      "tone": "light",
+      "previewFontFamily": "'Inter', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "#0f172a",
+        "textSecondary": "#1f2937",
+        "textMuted": "#64748b",
+        "border": "rgba(15, 118, 110, 0.12)",
+        "borderStrong": "rgba(15, 118, 110, 0.22)",
+        "surface": "#ffffff",
+        "surfaceSoft": "rgba(207, 250, 254, 0.65)",
+        "surfaceSubtle": "rgba(207, 250, 254, 0.45)",
+        "progressTrack": "rgba(20, 184, 166, 0.2)",
+        "shadow": "0 24px 48px rgba(15, 118, 110, 0.15)"
+      }
+    },
+    {
+      "id": "clockwork-brass",
+      "label": "Latão de Engrenagens",
+      "description": "Steampunk elegante com dourado envelhecido e turquesa profundo.",
+      "accent": "#d97706",
+      "softAccent": "rgba(217, 119, 6, 0.28)",
+      "previewGradient": "linear-gradient(135deg, #120d08 0%, #2f2015 45%, #8b5f30 100%)",
+      "tone": "dark",
+      "previewFontFamily": "'Cinzel Decorative', 'Great Vibes', 'Inter', serif",
+      "profile": {
+        "textPrimary": "var(--hk-text-primary)",
+        "textSecondary": "var(--hk-text-secondary)",
+        "textMuted": "var(--hk-text-muted)",
+        "border": "rgba(255, 255, 255, 0.1)",
+        "borderStrong": "rgba(255, 255, 255, 0.2)",
+        "surface": "rgba(24, 17, 10, 0.9)",
+        "surfaceSoft": "rgba(255, 255, 255, 0.07)",
+        "surfaceSubtle": "rgba(255, 255, 255, 0.04)",
+        "progressTrack": "rgba(20, 184, 166, 0.2)",
+        "shadow": "0 32px 64px rgba(12, 8, 4, 0.52)"
+      }
+    },
+    {
+      "id": "ember-forge",
+      "label": "Forja em Brasas",
+      "description": "Paleta vibrante inspirada em brasas e metais aquecidos.",
+      "accent": "#f97316",
+      "softAccent": "rgba(249, 115, 22, 0.22)",
+      "previewGradient": "linear-gradient(135deg, #2d1b18 0%, #7c2d12 100%)",
+      "tone": "dark",
+      "previewFontFamily": "'Rubik', 'Inter', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "var(--hk-text-primary)",
+        "textSecondary": "var(--hk-text-secondary)",
+        "textMuted": "var(--hk-text-muted)",
+        "border": "rgba(255, 255, 255, 0.08)",
+        "borderStrong": "rgba(255, 255, 255, 0.18)",
+        "surface": "rgba(13, 16, 34, 0.8)",
+        "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+        "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+        "progressTrack": "rgba(124, 92, 255, 0.16)",
+        "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+      }
+    },
+    {
+      "id": "nebula-pulse",
+      "label": "Pulso da Nebulosa",
+      "description": "Explosão psicodélica de tons neon entre magenta, ciano e verde elétrico.",
+      "accent": "#ff4ecd",
+      "softAccent": "rgba(255, 78, 205, 0.26)",
+      "previewGradient": "linear-gradient(135deg, #050014 0%, #1a0b3c 35%, #004f7a 68%, #0affc2 100%)",
+      "tone": "dark",
+      "previewFontFamily": "'Chakra Petch', 'Space Grotesk', 'Inter', sans-serif",
+      "profile": {
+        "textPrimary": "var(--hk-text-primary)",
+        "textSecondary": "var(--hk-text-secondary)",
+        "textMuted": "var(--hk-text-muted)",
+        "border": "rgba(255, 255, 255, 0.1)",
+        "borderStrong": "rgba(255, 255, 255, 0.2)",
+        "surface": "rgba(12, 10, 34, 0.8)",
+        "surfaceSoft": "rgba(255, 255, 255, 0.08)",
+        "surfaceSubtle": "rgba(255, 255, 255, 0.04)",
+        "progressTrack": "rgba(59, 130, 246, 0.22)",
+        "shadow": "0 30px 65px rgba(5, 0, 32, 0.5)"
+      }
+    },
+    {
+      "id": "polar-lumina",
+      "label": "Lúmina Polar",
+      "description": "Minimalismo ártico com azuis glaciais e reflexos prateados.",
+      "accent": "#1e90ff",
+      "softAccent": "rgba(30, 144, 255, 0.18)",
+      "previewGradient": "linear-gradient(135deg, #ffffff 0%, #e0f2ff 55%, #9bd0ff 100%)",
+      "tone": "light",
+      "previewFontFamily": "'Inter', 'Space Grotesk', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "#0b1b2a",
+        "textSecondary": "rgba(11, 27, 42, 0.74)",
+        "textMuted": "rgba(11, 27, 42, 0.52)",
+        "border": "rgba(30, 144, 255, 0.16)",
+        "borderStrong": "rgba(30, 144, 255, 0.28)",
+        "surface": "#ffffff",
+        "surfaceSoft": "#f1f9ff",
+        "surfaceSubtle": "#e0f2ff",
+        "progressTrack": "rgba(30, 144, 255, 0.22)",
+        "shadow": "0 18px 36px rgba(10, 34, 54, 0.16)"
+      }
+    },
+    {
+      "id": "quantum-mist",
+      "label": "Neblina Quântica",
+      "description": "Tons futuristas de lilás e ciano com brilho metálico.",
+      "accent": "#a855f7",
+      "softAccent": "rgba(168, 85, 247, 0.26)",
+      "previewGradient": "linear-gradient(135deg, #1a1033 0%, #3a1a5a 100%)",
+      "tone": "dark",
+      "previewFontFamily": "'Space Grotesk', 'Inter', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "var(--hk-text-primary)",
+        "textSecondary": "var(--hk-text-secondary)",
+        "textMuted": "var(--hk-text-muted)",
+        "border": "rgba(255, 255, 255, 0.08)",
+        "borderStrong": "rgba(255, 255, 255, 0.18)",
+        "surface": "rgba(13, 16, 34, 0.8)",
+        "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+        "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+        "progressTrack": "rgba(124, 92, 255, 0.16)",
+        "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+      }
+    },
+    {
+      "id": "radiant-dawn",
+      "label": "Aurora Matinal",
+      "description": "Tema claro com foco em clareza e contrastes azulados.",
+      "accent": "#2563eb",
+      "softAccent": "rgba(37, 99, 235, 0.18)",
+      "previewGradient": "linear-gradient(135deg, #f1f5ff 0%, #cfe1ff 100%)",
+      "tone": "light",
+      "previewFontFamily": "'Inter', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "#0f172a",
+        "textSecondary": "#1f2937",
+        "textMuted": "#64748b",
+        "border": "rgba(15, 23, 42, 0.08)",
+        "borderStrong": "rgba(15, 23, 42, 0.16)",
+        "surface": "#ffffff",
+        "surfaceSoft": "rgba(226, 232, 240, 0.65)",
+        "surfaceSubtle": "rgba(226, 232, 240, 0.45)",
+        "progressTrack": "rgba(15, 23, 42, 0.1)",
+        "shadow": "0 24px 48px rgba(15, 23, 42, 0.12)"
+      }
+    },
+    {
+      "id": "royal-manuscript",
+      "label": "Manuscrito Real",
+      "description": "Tema medieval com dourado envelhecido e textura de pergaminho.",
+      "accent": "#b4592d",
+      "softAccent": "rgba(180, 89, 45, 0.26)",
+      "previewGradient": "linear-gradient(135deg, #f6e7c2 0%, #d8a162 55%, #7c2f1d 100%)",
+      "tone": "light",
+      "previewFontFamily": "'Great Vibes', 'Cinzel Decorative', 'Segoe Script', 'Lucida Handwriting', cursive",
+      "profile": {
+        "textPrimary": "#2f1c0f",
+        "textSecondary": "rgba(47, 28, 15, 0.76)",
+        "textMuted": "rgba(47, 28, 15, 0.58)",
+        "border": "rgba(124, 71, 34, 0.3)",
+        "borderStrong": "rgba(124, 71, 34, 0.48)",
+        "surface": "#f7e8c8",
+        "surfaceSoft": "#efd6a8",
+        "surfaceSubtle": "#e3c48b",
+        "progressTrack": "rgba(180, 89, 45, 0.22)",
+        "shadow": "0 28px 60px rgba(96, 54, 23, 0.25)"
+      }
+    },
+    {
+      "id": "stellar-night",
+      "label": "Noite Estelar",
+      "description": "Tema original com tons profundos e acento violeta.",
+      "accent": "#7c5cff",
+      "softAccent": "rgba(124, 92, 255, 0.28)",
+      "previewGradient": "linear-gradient(135deg, #1b1933 0%, #433978 100%)",
+      "tone": "dark",
+      "previewFontFamily": "'Chakra Petch', 'Inter', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "var(--hk-text-primary)",
+        "textSecondary": "var(--hk-text-secondary)",
+        "textMuted": "var(--hk-text-muted)",
+        "border": "rgba(255, 255, 255, 0.08)",
+        "borderStrong": "rgba(255, 255, 255, 0.18)",
+        "surface": "rgba(13, 16, 34, 0.8)",
+        "surfaceSoft": "rgba(255, 255, 255, 0.06)",
+        "surfaceSubtle": "rgba(255, 255, 255, 0.03)",
+        "progressTrack": "rgba(124, 92, 255, 0.16)",
+        "shadow": "0 28px 60px rgba(10, 12, 28, 0.45)"
+      }
+    },
+    {
+      "id": "sunset-boulevard",
+      "label": "Boulevard do Pôr do Sol",
+      "description": "Estética retrô com coral, pêssego e lilás inspirados em neons californianos.",
+      "accent": "#fb7185",
+      "softAccent": "rgba(251, 113, 133, 0.22)",
+      "previewGradient": "linear-gradient(135deg, #1a142f 0%, #4c1d95 45%, #fb7185 100%)",
+      "tone": "dark",
+      "previewFontFamily": "'Space Grotesk', 'Inter', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "var(--hk-text-primary)",
+        "textSecondary": "var(--hk-text-secondary)",
+        "textMuted": "var(--hk-text-muted)",
+        "border": "rgba(255, 255, 255, 0.08)",
+        "borderStrong": "rgba(255, 255, 255, 0.18)",
+        "surface": "rgba(24, 18, 48, 0.86)",
+        "surfaceSoft": "rgba(255, 255, 255, 0.07)",
+        "surfaceSubtle": "rgba(255, 255, 255, 0.04)",
+        "progressTrack": "rgba(129, 140, 248, 0.22)",
+        "shadow": "0 28px 60px rgba(22, 16, 44, 0.46)"
+      }
+    },
+    {
+      "id": "verdant-sanctuary",
+      "label": "Santuário Verdejante",
+      "description": "Tema claro botânico com verdes terapêuticos e detalhes em cobre.",
+      "accent": "#0f9d58",
+      "softAccent": "rgba(15, 157, 88, 0.18)",
+      "previewGradient": "linear-gradient(135deg, #f3fff3 0%, #d4f7df 55%, #8bd4a1 100%)",
+      "tone": "light",
+      "previewFontFamily": "'Inter', 'Rubik', 'Segoe UI', sans-serif",
+      "profile": {
+        "textPrimary": "#12261a",
+        "textSecondary": "rgba(18, 38, 26, 0.76)",
+        "textMuted": "rgba(18, 38, 26, 0.54)",
+        "border": "rgba(15, 157, 88, 0.18)",
+        "borderStrong": "rgba(15, 157, 88, 0.28)",
+        "surface": "#ffffff",
+        "surfaceSoft": "#ecfdf5",
+        "surfaceSubtle": "#d1fae5",
+        "progressTrack": "rgba(15, 157, 88, 0.22)",
+        "shadow": "0 20px 40px rgba(12, 83, 45, 0.18)"
+      }
+    }
+  ]
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,21 +1,34 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
+  let httpTestingController: HttpTestingController;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should create the app shell', () => {
     const fixture = TestBed.createComponent(AppComponent);
+    httpTestingController.expectOne('http://localhost:3000/themes').flush([]);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
   it('should render the navigation brand', () => {
     const fixture = TestBed.createComponent(AppComponent);
+    httpTestingController.expectOne('http://localhost:3000/themes').flush([]);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.shell-header__titles a')?.textContent?.trim()).toBe('Hero Kanban');
@@ -23,6 +36,7 @@ describe('AppComponent', () => {
 
   it('should toggle the lateral menu visibility', () => {
     const fixture = TestBed.createComponent(AppComponent);
+    httpTestingController.expectOne('http://localhost:3000/themes').flush([]);
     const component = fixture.componentInstance;
 
     expect(component.isMenuOpen()).toBeFalse();

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,5 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
@@ -6,6 +7,7 @@ import { routes } from './app.routes';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
+    provideHttpClient(withFetch()),
     provideRouter(routes),
     provideAnimationsAsync(),
   ],

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -1,0 +1,40 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators';
+import type { Observable } from 'rxjs';
+
+import type { ThemeOption, ThemeProfileTokens, ThemeTone } from '../state/theme.state';
+
+type ThemeDto = {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly accent: string;
+  readonly softAccent: string;
+  readonly previewGradient: string;
+  readonly tone: ThemeTone;
+  readonly previewFontFamily: string;
+  readonly profile?: ThemeProfileTokens;
+};
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly httpClient = inject(HttpClient);
+
+  private readonly resourceUrl = 'http://localhost:3000/themes';
+
+  getThemes(): Observable<readonly ThemeOption[]> {
+    return this.httpClient.get<readonly ThemeDto[]>(this.resourceUrl).pipe(
+      map((themes) => themes.map((theme) => this.mapDtoToThemeOption(theme))),
+    );
+  }
+
+  private mapDtoToThemeOption(dto: ThemeDto): ThemeOption {
+    const { profile, ...rest } = dto;
+
+    return Object.freeze({
+      ...rest,
+      profile: profile ? Object.freeze({ ...profile }) : undefined,
+    }) as ThemeOption;
+  }
+}

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -39,6 +39,34 @@ export class ThemeState {
     this.applyTheme(this._currentTheme());
   }
 
+  setAvailableThemes(themes: readonly ThemeOption[]): void {
+    if (themes.length === 0) {
+      return;
+    }
+
+    const normalizedThemes = Object.freeze(
+      themes.map((theme) => Object.freeze({ ...theme })),
+    ) as readonly ThemeOption[];
+
+    this._themes.set(normalizedThemes);
+
+    const currentThemeId = this._currentTheme();
+    const hasCurrentTheme = normalizedThemes.some((theme) => theme.id === currentThemeId);
+
+    if (!hasCurrentTheme) {
+      const [firstTheme] = normalizedThemes;
+
+      if (firstTheme) {
+        this._currentTheme.set(firstTheme.id as ThemeId);
+        this.applyTheme(firstTheme.id as ThemeId);
+      }
+
+      return;
+    }
+
+    this.applyTheme(currentThemeId);
+  }
+
   setTheme(themeId: ThemeId): void {
     if (this._currentTheme() === themeId) {
       return;


### PR DESCRIPTION
## Summary
- add a json-server database with all current themes and a helper npm script to run it
- introduce ThemeService to load themes over HTTP and hydrate ThemeState from AppComponent
- update tests to mock the HTTP backend when creating AppComponent

## Testing
- npm test -- --watch=false *(fails: Chrome browser is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29caef2708333aff781de769db10c