### PR TITLE
feat: add collaborative story discussions

### DIFF
--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -100,6 +100,106 @@
     </div>
   </section>
 
+  <mat-card class="board__conversations" aria-label="Discussões recentes do quadro">
+    <mat-card-header>
+      <mat-card-title>Discussões recentes</mat-card-title>
+      <mat-card-subtitle>Mantenha a guilda informada e destaque menções críticas.</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <section class="board__conversation-form" aria-label="Publicar novo comentário rápido">
+        <form
+          class="board__conversation-form-fields"
+          [formGroup]="quickCommentForm"
+          (ngSubmit)="onSubmitQuickComment()"
+          aria-describedby="board-conversation-hint"
+          novalidate
+        >
+          <div class="board__conversation-row">
+            <mat-form-field appearance="fill">
+              <mat-label>História</mat-label>
+              <mat-select formControlName="storyId" required aria-required="true">
+                <mat-option *ngFor="let option of storyOptions()" [value]="option.id">
+                  {{ option.title }}
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
+
+            <mat-form-field appearance="fill">
+              <mat-label>Autor</mat-label>
+              <input
+                matInput
+                type="text"
+                formControlName="author"
+                required
+                aria-required="true"
+                placeholder="Nome de quem publica"
+              />
+              <mat-hint id="board-conversation-hint">Use &#64; para mencionar colegas e ativar alertas.</mat-hint>
+            </mat-form-field>
+          </div>
+
+          <mat-form-field appearance="fill" class="board__conversation-message">
+            <mat-label>Mensagem</mat-label>
+            <textarea
+              matInput
+              formControlName="message"
+              rows="3"
+              required
+              aria-required="true"
+              placeholder="Compartilhe atualizações e menções relevantes"
+            ></textarea>
+          </mat-form-field>
+
+          <div class="board__conversation-actions">
+            <button type="submit" mat-flat-button color="primary">
+              <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">send</mat-icon>
+              Publicar atualização
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="board__conversation-thread" aria-label="Comentários mais recentes">
+        <ol *ngIf="recentComments().length > 0; else emptyComments" class="board__comment-list">
+          <li
+            *ngFor="let entry of recentComments(); trackBy: trackRecentComment"
+            class="board__comment-item"
+          >
+            <article>
+              <header class="board__comment-header">
+                <span class="board__comment-author">{{ entry.comment.author }}</span>
+                <span class="board__comment-story">
+                  {{ entry.storyTitle }} ·
+                  <time [attr.datetime]="entry.comment.createdAtIso">
+                    {{ entry.comment.createdAtIso | date: 'short' }}
+                  </time>
+                </span>
+              </header>
+              <p class="board__comment-message">{{ entry.comment.message }}</p>
+              <div
+                *ngIf="entry.comment.mentions.length > 0"
+                class="board__comment-mentions"
+                aria-label="Menções registradas"
+              >
+                <mat-chip-set>
+                  <mat-chip *ngFor="let mention of entry.comment.mentions" color="primary" selected>
+                    &#64;{{ mention }}
+                  </mat-chip>
+                </mat-chip-set>
+              </div>
+            </article>
+          </li>
+        </ol>
+        <ng-template #emptyComments>
+          <p class="board__comment-empty" role="status">
+            Ainda não temos conversas registradas aqui. Que tal iniciar uma atualização para o squad?
+          </p>
+        </ng-template>
+      </section>
+    </mat-card-content>
+  </mat-card>
+
   <section class="board__columns" role="list">
     <kanban-board-column
       *ngFor="let column of columns(); trackBy: trackColumn"

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -315,3 +315,113 @@
   background: rgba(var(--hk-accent-strong-rgb), 0.35);
   border-radius: 999px;
 }
+
+.board__conversations {
+  background: var(--hk-surface);
+  border: 1px solid var(--hk-border);
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 48px -24px rgba(var(--hk-accent-strong-rgb), 0.45);
+  margin-inline: clamp(0.5rem, 2vw, 1.25rem);
+}
+
+.board__conversations .mat-mdc-card-header,
+.board__conversations .mat-mdc-card-content {
+  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.board__conversation-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.board__conversation-form-fields {
+  display: grid;
+  gap: 1rem;
+}
+
+.board__conversation-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.board__conversation-message {
+  width: 100%;
+}
+
+.board__conversation-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.board__conversation-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  border-radius: 999px;
+}
+
+.board__conversation-thread {
+  display: grid;
+  gap: 1rem;
+}
+
+.board__comment-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.board__comment-item {
+  background: color-mix(in srgb, var(--hk-surface-elevated) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 85%, transparent);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.board__comment-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+
+.board__comment-author {
+  font-weight: 700;
+  color: var(--hk-text-primary);
+}
+
+.board__comment-story {
+  color: var(--hk-text-muted);
+  font-size: 0.85rem;
+}
+
+.board__comment-message {
+  margin: 0;
+  color: var(--hk-text-secondary);
+  line-height: 1.5;
+}
+
+.board__comment-mentions {
+  margin-top: 0.75rem;
+}
+
+.board__comment-mentions mat-chip-set {
+  gap: 0.35rem;
+}
+
+.board__comment-empty {
+  margin: 0;
+  color: var(--hk-text-muted);
+  background: color-mix(in srgb, var(--hk-accent) 12%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--hk-accent-strong) 35%, transparent);
+  border-radius: 1rem;
+  padding: 1rem 1.5rem;
+  text-align: center;
+}

--- a/src/app/features/board/pages/board.page.ts
+++ b/src/app/features/board/pages/board.page.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import { DecimalPipe, NgFor, NgIf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { DatePipe, DecimalPipe, NgFor, NgIf } from '@angular/common';
+import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatChipsModule } from '@angular/material/chips';
@@ -9,11 +10,20 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatOptionModule } from '@angular/material/core';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 
-import type { BoardColumnViewModel, CreateStoryPayload } from '../state/board.models';
+import type { BoardColumnViewModel, CreateStoryPayload, StoryComment } from '../state/board.models';
 import { BoardState } from '../state/board-state.service';
 import { BoardColumnComponent } from '../components/board-column/board-column.component';
 import { CreateStoryModalComponent } from '../components/create-story-modal/create-story-modal.component';
+import { StoryCommentsState } from '../state/story-comments.state';
+
+interface RecentComment {
+  readonly storyId: string;
+  readonly storyTitle: string;
+  readonly comment: StoryComment;
+}
 
 @Component({
   selector: 'hk-board-page',
@@ -25,6 +35,7 @@ import { CreateStoryModalComponent } from '../components/create-story-modal/crea
     NgFor,
     NgIf,
     DecimalPipe,
+    DatePipe,
     BoardColumnComponent,
     CreateStoryModalComponent,
     MatButtonModule,
@@ -36,10 +47,16 @@ import { CreateStoryModalComponent } from '../components/create-story-modal/crea
     MatSelectModule,
     MatOptionModule,
     MatDividerModule,
+    MatInputModule,
+    MatSnackBarModule,
+    ReactiveFormsModule,
   ],
 })
 export class BoardPageComponent {
   private readonly boardState = inject(BoardState);
+  private readonly commentsState = inject(StoryCommentsState);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly formBuilder = inject(NonNullableFormBuilder);
 
   protected readonly columns = this.boardState.columns;
   protected readonly summary = this.boardState.summary;
@@ -49,9 +66,64 @@ export class BoardPageComponent {
   protected readonly sprintOptions = this.boardState.sprintFilterOptions;
   protected readonly selectedSprintId = this.boardState.selectedSprintId;
   protected readonly isCreatingStory = signal(false);
+  protected readonly storyOptions = computed(() =>
+    this.boardState
+      .stories()
+      .map((story) => ({ id: story.id, title: story.title, assignee: story.assignee })),
+  );
+
+  protected readonly recentComments = computed<readonly RecentComment[]>(() => {
+    return this.boardState
+      .stories()
+      .flatMap((story) =>
+        story.comments.map(
+          (comment) =>
+            ({
+              storyId: story.id,
+              storyTitle: story.title,
+              comment,
+            }) satisfies RecentComment,
+        ),
+      )
+      .sort((a, b) => Date.parse(b.comment.createdAtIso) - Date.parse(a.comment.createdAtIso))
+      .slice(0, 4);
+  });
+
+  protected readonly quickCommentForm = this.formBuilder.group({
+    storyId: this.formBuilder.control('', Validators.required),
+    author: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    message: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+  });
+
+  private readonly hydrateFormDefaults = effect(
+    () => {
+      const stories = this.boardState.stories();
+      if (stories.length === 0) {
+        return;
+      }
+
+      const currentStoryId = this.quickCommentForm.controls.storyId.value;
+      if (!currentStoryId || !stories.some((story) => story.id === currentStoryId)) {
+        this.quickCommentForm.controls.storyId.setValue(stories[0]?.id ?? '');
+      }
+
+      const currentAuthor = this.quickCommentForm.controls.author.value;
+      if (currentAuthor.length === 0) {
+        const defaultAssignee = stories.find((story) => story.id === this.quickCommentForm.controls.storyId.value)?.assignee;
+        if (defaultAssignee) {
+          this.quickCommentForm.controls.author.setValue(defaultAssignee);
+        }
+      }
+    },
+    { allowSignalWrites: true },
+  );
 
   protected trackColumn(_: number, column: BoardColumnViewModel): string {
     return column.status.id;
+  }
+
+  protected trackRecentComment(_: number, entry: RecentComment): string {
+    return entry.comment.id;
   }
 
   protected openCreateStory(): void {
@@ -71,5 +143,42 @@ export class BoardPageComponent {
 
   protected onSprintFilterSelected(sprintId: string): void {
     this.boardState.setSprintFilter(sprintId);
+  }
+
+  protected onSubmitQuickComment(): void {
+    if (this.quickCommentForm.invalid) {
+      this.quickCommentForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.quickCommentForm.getRawValue();
+    const created = this.commentsState.addComment(value.storyId, {
+      author: value.author,
+      message: value.message,
+    });
+
+    if (!created) {
+      this.snackBar.open('Não foi possível registrar o comentário. Confira os campos e tente novamente.', 'Fechar', {
+        duration: 4000,
+      });
+      return;
+    }
+
+    this.quickCommentForm.controls.message.setValue('');
+    this.quickCommentForm.controls.message.markAsPristine();
+    this.quickCommentForm.controls.message.markAsUntouched();
+
+    const storyTitle = this.storyOptions().find((option) => option.id === value.storyId)?.title ?? 'história selecionada';
+    if (created.mentions.length > 0) {
+      this.snackBar.open(
+        `Menção enviada para ${created.mentions.join(', ')} em ${storyTitle}.`,
+        'Ok',
+        { duration: 5000 },
+      );
+    } else {
+      this.snackBar.open(`Comentário publicado em ${storyTitle}.`, 'Ok', {
+        duration: 3500,
+      });
+    }
   }
 }

--- a/src/app/features/board/pages/story-details/story-details.page.html
+++ b/src/app/features/board/pages/story-details/story-details.page.html
@@ -93,6 +93,238 @@
         </li>
       </ul>
     </section>
+
+    <section class="story-details__attachments" aria-label="Anexos da missão">
+      <header class="story-details__section-header">
+        <h2>Anexos</h2>
+        <p aria-live="polite">{{ attachments().length }} {{ attachments().length === 1 ? 'arquivo' : 'arquivos' }}</p>
+      </header>
+
+      <ul *ngIf="attachments().length > 0; else noAttachments" class="story-details__attachment-list">
+        <li *ngFor="let attachment of attachments(); trackBy: trackAttachment" class="story-details__attachment">
+          <article>
+            <div class="story-details__attachment-info">
+              <span class="material-symbols-rounded" aria-hidden="true">attach_file</span>
+              <div>
+                <a
+                  class="story-details__attachment-link"
+                  [href]="attachment.downloadUrl"
+                  target="_blank"
+                  rel="noopener"
+                >
+                  {{ attachment.fileName }}
+                </a>
+                <p>
+                  {{ attachment.fileSizeLabel }} · enviado por {{ attachment.uploadedBy }} em
+                  <time [attr.datetime]="attachment.uploadedAtIso">{{ attachment.uploadedAtIso | date: 'short' }}</time>
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              mat-stroked-button
+              color="warn"
+              (click)="removeAttachment(attachment.id)"
+            >
+              Remover
+            </button>
+          </article>
+        </li>
+      </ul>
+      <ng-template #noAttachments>
+        <p class="story-details__empty-attachments" role="status">
+          Nenhum arquivo anexado ainda. Compartilhe documentos relevantes com o squad.
+        </p>
+      </ng-template>
+
+      <form
+        class="story-details__attachment-form"
+        [formGroup]="attachmentForm"
+        (ngSubmit)="onSubmitAttachment()"
+        novalidate
+      >
+        <div class="story-details__attachment-fields">
+          <mat-form-field appearance="fill">
+            <mat-label>Nome do arquivo</mat-label>
+            <input matInput type="text" formControlName="fileName" required aria-required="true" />
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>Tamanho</mat-label>
+            <input matInput type="text" formControlName="fileSizeLabel" required aria-required="true" />
+          </mat-form-field>
+        </div>
+        <div class="story-details__attachment-fields">
+          <mat-form-field appearance="fill">
+            <mat-label>Responsável</mat-label>
+            <input matInput type="text" formControlName="uploadedBy" required aria-required="true" />
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>Link (opcional)</mat-label>
+            <input matInput type="url" formControlName="downloadUrl" />
+          </mat-form-field>
+        </div>
+        <button type="submit" mat-stroked-button color="primary">
+          <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">upload</mat-icon>
+          Anexar arquivo
+        </button>
+      </form>
+    </section>
+
+    <section class="story-details__discussion" aria-label="Discussões da missão">
+      <header class="story-details__section-header">
+        <h2>Discussão</h2>
+        <p aria-live="polite">{{ comments().length }} {{ comments().length === 1 ? 'comentário' : 'comentários' }}</p>
+      </header>
+
+      <form
+        class="story-details__comment-form"
+        [formGroup]="commentForm"
+        (ngSubmit)="onSubmitComment()"
+        novalidate
+      >
+        <div class="story-details__comment-row">
+          <mat-form-field appearance="fill">
+            <mat-label>Autor</mat-label>
+            <input matInput type="text" formControlName="author" required aria-required="true" />
+          </mat-form-field>
+        </div>
+        <mat-form-field appearance="fill">
+          <mat-label>Mensagem</mat-label>
+          <textarea
+            matInput
+            rows="3"
+            formControlName="message"
+            required
+            aria-required="true"
+            placeholder="Use &#64; para mencionar integrantes da guilda"
+          ></textarea>
+        </mat-form-field>
+        <button type="submit" mat-flat-button color="primary">
+          <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">forum</mat-icon>
+          Registrar comentário
+        </button>
+      </form>
+
+      <ol *ngIf="comments().length > 0; else noComments" class="story-details__comment-thread">
+        <li *ngFor="let comment of comments(); trackBy: trackComment" class="story-details__comment">
+          <article>
+            <header class="story-details__comment-header">
+              <div class="story-details__comment-avatar" aria-hidden="true">{{ comment.authorInitials }}</div>
+              <div>
+                <strong class="story-details__comment-author">{{ comment.author }}</strong>
+                <p class="story-details__comment-meta">
+                  <time [attr.datetime]="comment.createdAtIso">{{ comment.createdAtIso | date: 'short' }}</time>
+                  <span *ngIf="comment.isEdited" class="story-details__comment-edited">· editado</span>
+                </p>
+              </div>
+            </header>
+
+            <p *ngIf="editingCommentId() !== comment.id" class="story-details__comment-message">
+              {{ comment.message }}
+            </p>
+
+            <form
+              *ngIf="editingCommentId() === comment.id"
+              class="story-details__edit-form"
+              [formGroup]="editCommentForm"
+              (ngSubmit)="onSubmitEdit(comment.id)"
+            >
+              <mat-form-field appearance="fill">
+                <mat-label>Editar comentário</mat-label>
+                <textarea matInput rows="3" formControlName="message" required aria-required="true"></textarea>
+              </mat-form-field>
+              <div class="story-details__edit-actions">
+                <button type="button" mat-stroked-button color="warn" (click)="cancelEdit()">Cancelar</button>
+                <button type="submit" mat-flat-button color="primary">Salvar alterações</button>
+              </div>
+            </form>
+
+            <div
+              *ngIf="comment.mentions.length > 0"
+              class="story-details__comment-mentions"
+              aria-label="Menções"
+            >
+              <mat-chip-set>
+                <mat-chip *ngFor="let mention of comment.mentions" color="primary" selected>
+                  &#64;{{ mention }}
+                </mat-chip>
+              </mat-chip-set>
+            </div>
+
+            <div class="story-details__comment-actions">
+              <button type="button" mat-button (click)="beginReply(comment)">
+                <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">reply</mat-icon>
+                Responder
+              </button>
+              <button type="button" mat-button (click)="beginEdit(comment)">
+                <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">edit</mat-icon>
+                Editar
+              </button>
+            </div>
+
+            <ul *ngIf="comment.replies.length > 0" class="story-details__reply-list">
+              <li *ngFor="let reply of comment.replies" class="story-details__reply">
+                <header class="story-details__reply-header">
+                  <span class="story-details__reply-avatar" aria-hidden="true">{{ reply.authorInitials }}</span>
+                  <div>
+                    <strong>{{ reply.author }}</strong>
+                    <p class="story-details__reply-meta">
+                      <time [attr.datetime]="reply.createdAtIso">{{ reply.createdAtIso | date: 'short' }}</time>
+                      <span *ngIf="reply.isEdited" class="story-details__comment-edited">· editado</span>
+                    </p>
+                  </div>
+                </header>
+                <p class="story-details__reply-message">{{ reply.message }}</p>
+              </li>
+            </ul>
+
+            <form
+              *ngIf="replyingToCommentId() === comment.id"
+              class="story-details__reply-form"
+              [formGroup]="replyForm"
+              (ngSubmit)="onSubmitReply(comment.id)"
+            >
+              <mat-form-field appearance="fill">
+                <mat-label>Autor da resposta</mat-label>
+                <input matInput type="text" formControlName="author" required aria-required="true" />
+              </mat-form-field>
+              <mat-form-field appearance="fill">
+                <mat-label>Resposta</mat-label>
+                <textarea matInput rows="2" formControlName="message" required aria-required="true"></textarea>
+              </mat-form-field>
+              <div class="story-details__reply-actions">
+                <button type="button" mat-stroked-button color="warn" (click)="cancelReply()">Cancelar</button>
+                <button type="submit" mat-flat-button color="primary">Enviar resposta</button>
+              </div>
+            </form>
+          </article>
+        </li>
+      </ol>
+      <ng-template #noComments>
+        <p class="story-details__empty-thread" role="status">
+          Ninguém comentou ainda. Use o formulário acima para iniciar a conversa.
+        </p>
+      </ng-template>
+    </section>
+
+    <section class="story-details__history" aria-label="Histórico da missão">
+      <h2>Histórico</h2>
+      <ol class="story-details__history-list">
+        <li *ngFor="let event of history(); trackBy: trackHistory" class="story-details__history-item">
+          <span class="story-details__history-icon" aria-hidden="true">
+            <span class="material-symbols-rounded">{{ historyIcon(event.kind) }}</span>
+          </span>
+          <div>
+            <p class="story-details__history-summary">{{ event.summary }}</p>
+            <p class="story-details__history-description" *ngIf="event.description">{{ event.description }}</p>
+            <p class="story-details__history-meta">
+              {{ event.actor }} ·
+              <time [attr.datetime]="event.createdAtIso">{{ event.createdAtIso | date: 'short' }}</time>
+            </p>
+          </div>
+        </li>
+      </ol>
+    </section>
   </article>
 </section>
 

--- a/src/app/features/board/pages/story-details/story-details.page.scss
+++ b/src/app/features/board/pages/story-details/story-details.page.scss
@@ -358,3 +358,289 @@
     width: 100%;
   }
 }
+
+.story-details__section-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.story-details__section-header > p {
+  margin: 0;
+  color: var(--hk-text-muted);
+  font-size: 0.9rem;
+}
+
+.story-details__attachments,
+.story-details__discussion,
+.story-details__history {
+  background: var(--story-details-elevated-surface);
+  border: 1px solid var(--story-details-muted-border);
+  border-radius: 1.25rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.story-details__attachment-list,
+.story-details__comment-thread,
+.story-details__history-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.story-details__attachment {
+  background: var(--story-details-muted-surface);
+  border: 1px solid var(--story-details-muted-border);
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+}
+
+.story-details__attachment article {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 720px) {
+  .story-details__attachment article {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.story-details__attachment-info {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.story-details__attachment-info p {
+  margin: 0;
+  color: var(--hk-text-muted);
+  font-size: 0.85rem;
+}
+
+.story-details__attachment-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--story-details-primary-color);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.story-details__attachment-link:hover,
+.story-details__attachment-link:focus-visible {
+  text-decoration: underline;
+}
+
+.story-details__attachment-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.story-details__attachment-fields {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.story-details__empty-attachments,
+.story-details__empty-thread {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px dashed var(--story-details-muted-border);
+  color: var(--hk-text-muted);
+  background: color-mix(in srgb, var(--story-details-primary-color) 12%, transparent);
+}
+
+.story-details__comment-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.story-details__comment-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.story-details__comment-thread {
+  margin-top: 0.5rem;
+}
+
+.story-details__comment {
+  background: var(--story-details-muted-surface);
+  border: 1px solid var(--story-details-muted-border);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.story-details__comment-header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.story-details__comment-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: var(--story-details-primary-soft);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: var(--hk-text-primary);
+}
+
+.story-details__comment-author {
+  margin: 0;
+  font-weight: 700;
+  color: var(--hk-text-primary);
+}
+
+.story-details__comment-meta {
+  margin: 0.15rem 0 0;
+  color: var(--hk-text-muted);
+  font-size: 0.85rem;
+}
+
+.story-details__comment-edited {
+  color: var(--hk-text-muted);
+}
+
+.story-details__comment-message {
+  margin: 0 0 0.75rem;
+  color: var(--hk-text-secondary);
+  line-height: 1.5;
+}
+
+.story-details__comment-mentions mat-chip-set {
+  gap: 0.35rem;
+}
+
+.story-details__comment-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.story-details__edit-form,
+.story-details__reply-form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.story-details__edit-actions,
+.story-details__reply-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.story-details__reply-list {
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.story-details__reply {
+  background: color-mix(in srgb, var(--story-details-primary-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--story-details-primary-border) 65%, transparent);
+  border-radius: 0.75rem;
+  padding: 0.85rem;
+}
+
+.story-details__reply-header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.story-details__reply-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--story-details-primary-color) 28%, transparent);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: var(--hk-text-primary);
+}
+
+.story-details__reply-meta {
+  margin: 0;
+  color: var(--hk-text-muted);
+  font-size: 0.8rem;
+}
+
+.story-details__reply-message {
+  margin: 0;
+  color: var(--hk-text-secondary);
+}
+
+.story-details__history-list {
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+.story-details__history-list::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0.5rem;
+  width: 2px;
+  background: color-mix(in srgb, var(--story-details-primary-border) 60%, transparent);
+  border-radius: 999px;
+}
+
+.story-details__history-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.story-details__history-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--story-details-primary-soft);
+  display: grid;
+  place-items: center;
+  color: var(--story-details-primary-color);
+  border: 1px solid var(--story-details-primary-border);
+}
+
+.story-details__history-summary {
+  margin: 0;
+  font-weight: 600;
+  color: var(--hk-text-primary);
+}
+
+.story-details__history-description {
+  margin: 0.25rem 0 0;
+  color: var(--hk-text-secondary);
+}
+
+.story-details__history-meta {
+  margin: 0.35rem 0 0;
+  color: var(--hk-text-muted);
+  font-size: 0.85rem;
+}

--- a/src/app/features/board/pages/story-details/story-details.page.ts
+++ b/src/app/features/board/pages/story-details/story-details.page.ts
@@ -1,10 +1,24 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
-import { NgFor, NgIf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { DatePipe, NgFor, NgIf } from '@angular/common';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
+import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { BoardState } from '../../state/board-state.service';
-import type { StoryDetailsTaskViewModel } from '../../state/board.models';
+import type {
+  StoryAttachment,
+  StoryComment,
+  StoryDetailsTaskViewModel,
+  StoryHistoryEvent,
+} from '../../state/board.models';
+import { StoryCommentsState } from '../../state/story-comments.state';
+import { StoryAttachmentsState } from '../../state/story-attachments.state';
 
 @Component({
   selector: 'hk-story-details-page',
@@ -12,11 +26,27 @@ import type { StoryDetailsTaskViewModel } from '../../state/board.models';
   templateUrl: './story-details.page.html',
   styleUrls: ['./story-details.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIf, NgFor, RouterLink],
+  imports: [
+    NgIf,
+    NgFor,
+    RouterLink,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatChipsModule,
+    MatSnackBarModule,
+    DatePipe,
+  ],
 })
 export class StoryDetailsPageComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly boardState = inject(BoardState);
+  private readonly commentsState = inject(StoryCommentsState);
+  private readonly attachmentsState = inject(StoryAttachmentsState);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly formBuilder = inject(NonNullableFormBuilder);
 
   private readonly storyId = toSignal(
     this.route.paramMap.pipe(map((params) => params.get('storyId'))),
@@ -28,7 +58,275 @@ export class StoryDetailsPageComponent {
     return id ? this.boardState.getStoryDetails(id) : null;
   });
 
+  protected readonly comments = computed<readonly StoryComment[]>(() => {
+    const id = this.storyId();
+    if (!id) {
+      return [];
+    }
+
+    return this.commentsState.commentsForStory(id)();
+  });
+
+  protected readonly attachments = computed<readonly StoryAttachment[]>(() => {
+    const id = this.storyId();
+    if (!id) {
+      return [];
+    }
+
+    return this.attachmentsState.attachmentsForStory(id)();
+  });
+
+  protected readonly history = computed<readonly StoryHistoryEvent[]>(() => {
+    const id = this.storyId();
+    if (!id) {
+      return [];
+    }
+
+    const storySignal = this.boardState.watchStory(id);
+    return storySignal()?.history ?? [];
+  });
+
+  protected readonly commentForm = this.formBuilder.group({
+    author: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    message: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+  });
+
+  protected readonly replyForm = this.formBuilder.group({
+    author: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    message: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+  });
+
+  protected readonly editCommentForm = this.formBuilder.group({
+    message: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+  });
+
+  protected readonly attachmentForm = this.formBuilder.group({
+    fileName: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    fileSizeLabel: this.formBuilder.control('1,0 MB', Validators.required),
+    uploadedBy: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    downloadUrl: this.formBuilder.control('#'),
+  });
+
+  protected readonly replyingToCommentId = signal<string | null>(null);
+  protected readonly editingCommentId = signal<string | null>(null);
+
+  private readonly hydrateDefaultAuthors = effect(
+    () => {
+      const details = this.story();
+      if (!details) {
+        return;
+      }
+
+      if (this.commentForm.controls.author.value.length === 0) {
+        this.commentForm.controls.author.setValue(details.assignee);
+      }
+
+      if (this.replyForm.controls.author.value.length === 0) {
+        this.replyForm.controls.author.setValue(details.assignee);
+      }
+
+      if (this.attachmentForm.controls.uploadedBy.value.length === 0) {
+        this.attachmentForm.controls.uploadedBy.setValue(details.assignee);
+      }
+    },
+    { allowSignalWrites: true },
+  );
+
   protected trackTask(_: number, task: StoryDetailsTaskViewModel): string {
     return task.id;
+  }
+
+  protected trackComment(_: number, comment: StoryComment): string {
+    return comment.id;
+  }
+
+  protected trackAttachment(_: number, attachment: StoryAttachment): string {
+    return attachment.id;
+  }
+
+  protected trackHistory(_: number, event: StoryHistoryEvent): string {
+    return event.id;
+  }
+
+  protected onSubmitComment(): void {
+    if (this.commentForm.invalid) {
+      this.commentForm.markAllAsTouched();
+      return;
+    }
+
+    const id = this.storyId();
+    if (!id) {
+      return;
+    }
+
+    const value = this.commentForm.getRawValue();
+    const created = this.commentsState.addComment(id, {
+      author: value.author,
+      message: value.message,
+    });
+
+    if (!created) {
+      this.snackBar.open('Não foi possível registrar o comentário.', 'Fechar', { duration: 4000 });
+      return;
+    }
+
+    this.commentForm.controls.message.setValue('');
+    this.commentForm.controls.message.markAsPristine();
+    this.commentForm.controls.message.markAsUntouched();
+
+    if (created.mentions.length > 0) {
+      this.snackBar.open(
+        `Menção enviada para ${created.mentions.join(', ')}.`,
+        'Ok',
+        { duration: 5000 },
+      );
+    } else {
+      this.snackBar.open('Comentário publicado.', 'Ok', { duration: 3500 });
+    }
+  }
+
+  protected beginReply(comment: StoryComment): void {
+    this.replyingToCommentId.set(comment.id);
+    if (this.replyForm.controls.author.value.length === 0) {
+      this.replyForm.controls.author.setValue(comment.author);
+    }
+    this.replyForm.controls.message.reset('');
+  }
+
+  protected cancelReply(): void {
+    this.replyingToCommentId.set(null);
+    this.replyForm.reset({
+      author: this.replyForm.controls.author.value,
+      message: '',
+    });
+  }
+
+  protected onSubmitReply(commentId: string): void {
+    if (this.replyForm.invalid) {
+      this.replyForm.markAllAsTouched();
+      return;
+    }
+
+    const id = this.storyId();
+    if (!id) {
+      return;
+    }
+
+    const value = this.replyForm.getRawValue();
+    const created = this.commentsState.replyToComment(id, commentId, {
+      author: value.author,
+      message: value.message,
+    });
+
+    if (!created) {
+      this.snackBar.open('Não foi possível publicar a resposta.', 'Fechar', { duration: 4000 });
+      return;
+    }
+
+    this.snackBar.open('Resposta publicada.', 'Ok', { duration: 3500 });
+    this.replyForm.reset({ author: value.author, message: '' });
+    this.replyingToCommentId.set(null);
+  }
+
+  protected beginEdit(comment: StoryComment): void {
+    this.editingCommentId.set(comment.id);
+    this.editCommentForm.controls.message.setValue(comment.message);
+  }
+
+  protected cancelEdit(): void {
+    this.editingCommentId.set(null);
+    this.editCommentForm.reset({ message: '' });
+  }
+
+  protected onSubmitEdit(commentId: string): void {
+    if (this.editCommentForm.invalid) {
+      this.editCommentForm.markAllAsTouched();
+      return;
+    }
+
+    const id = this.storyId();
+    if (!id) {
+      return;
+    }
+
+    const value = this.editCommentForm.getRawValue();
+    const updated = this.commentsState.updateComment(id, commentId, {
+      message: value.message,
+    });
+
+    if (!updated) {
+      this.snackBar.open('Não foi possível editar o comentário.', 'Fechar', { duration: 4000 });
+      return;
+    }
+
+    this.snackBar.open('Comentário atualizado.', 'Ok', { duration: 3500 });
+    this.cancelEdit();
+  }
+
+  protected onSubmitAttachment(): void {
+    if (this.attachmentForm.invalid) {
+      this.attachmentForm.markAllAsTouched();
+      return;
+    }
+
+    const id = this.storyId();
+    if (!id) {
+      return;
+    }
+
+    const value = this.attachmentForm.getRawValue();
+    const created = this.attachmentsState.uploadAttachment(id, {
+      fileName: value.fileName,
+      fileSizeLabel: value.fileSizeLabel,
+      uploadedBy: value.uploadedBy,
+      downloadUrl: value.downloadUrl,
+    });
+
+    if (!created) {
+      this.snackBar.open('Não foi possível anexar o arquivo.', 'Fechar', { duration: 4000 });
+      return;
+    }
+
+    this.snackBar.open('Anexo adicionado à missão.', 'Ok', { duration: 3500 });
+    this.attachmentForm.reset({
+      fileName: '',
+      fileSizeLabel: '1,0 MB',
+      uploadedBy: value.uploadedBy,
+      downloadUrl: '#',
+    });
+  }
+
+  protected removeAttachment(attachmentId: string): void {
+    const id = this.storyId();
+    if (!id) {
+      return;
+    }
+
+    const actor = this.commentForm.controls.author.value || this.story()?.assignee || 'Equipe';
+    const removed = this.attachmentsState.removeAttachment(id, attachmentId, actor);
+    if (!removed) {
+      this.snackBar.open('Não foi possível remover o anexo.', 'Fechar', { duration: 4000 });
+      return;
+    }
+
+    this.snackBar.open('Anexo removido.', 'Ok', { duration: 3500 });
+  }
+
+  protected historyIcon(kind: StoryHistoryEvent['kind']): string {
+    switch (kind) {
+      case 'comment_added':
+        return 'forum';
+      case 'comment_updated':
+        return 'edit';
+      case 'reply_added':
+        return 'quickreply';
+      case 'attachment_added':
+        return 'attach_file_add';
+      case 'attachment_removed':
+        return 'attach_file_off';
+      case 'status_change':
+      default:
+        return 'sync_alt';
+    }
   }
 }

--- a/src/app/features/board/state/board-state.service.ts
+++ b/src/app/features/board/state/board-state.service.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable, signal, Signal } from '@angular/core';
 import type {
   BoardCardViewModel,
   BoardColumnViewModel,
@@ -16,6 +16,9 @@ import type {
   SprintStoryTaskViewModel,
   SprintStoryViewModel,
   Story,
+  StoryAttachment,
+  StoryComment,
+  StoryHistoryEvent,
   StoryTask,
   StoryDetailsTaskViewModel,
   StoryDetailsViewModel,
@@ -187,6 +190,103 @@ export class BoardState {
         },
       ],
       dueDate: new Date().toISOString(),
+      comments: [
+        {
+          id: 'comment-flow-analytics-dashboard',
+          author: 'Helena Pires',
+          authorInitials: 'HP',
+          message:
+            'Atualizei os dashboards com métricas dos últimos 7 dias. @Aline Santos pode revisar se as narrativas fazem sentido?',
+          createdAtIso: '2024-06-11T13:15:00.000Z',
+          mentions: ['Aline Santos'],
+          isEdited: false,
+          replies: [
+            {
+              id: 'reply-flow-analytics-dashboard-review',
+              author: 'Aline Santos',
+              authorInitials: 'AS',
+              message:
+                'Já conferi e está pronto para compartilhar com o chapter. Vou anexar os highlights para o squad.',
+              createdAtIso: '2024-06-11T14:42:00.000Z',
+              mentions: [],
+              isEdited: false,
+            },
+          ],
+        },
+        {
+          id: 'comment-flow-analytics-tooltips',
+          author: 'Iuri Paiva',
+          authorInitials: 'IP',
+          message:
+            'Incluí microcópias nos tooltips explicando lead time e cycle time para reduzir dúvidas de onboarding.',
+          createdAtIso: '2024-06-12T09:25:00.000Z',
+          updatedAtIso: '2024-06-12T10:10:00.000Z',
+          mentions: ['Helena Pires'],
+          isEdited: true,
+          replies: [],
+        },
+      ],
+      attachments: [
+        {
+          id: 'attachment-flow-analytics-briefing',
+          fileName: 'briefing-narrativas-analytics.pdf',
+          fileSizeLabel: '1,3 MB',
+          uploadedBy: 'Aline Santos',
+          uploadedAtIso: '2024-06-10T15:30:00.000Z',
+          downloadUrl: '#',
+        },
+        {
+          id: 'attachment-flow-analytics-dashboard',
+          fileName: 'dashboard-preview.fig',
+          fileSizeLabel: '4,8 MB',
+          uploadedBy: 'Iuri Paiva',
+          uploadedAtIso: '2024-06-12T09:10:00.000Z',
+          downloadUrl: '#',
+        },
+      ],
+      history: [
+        {
+          id: 'history-flow-analytics-created',
+          kind: 'status_change',
+          actor: 'Aline Santos',
+          summary: 'História criada em Em desenvolvimento',
+          description: 'Aline Santos iniciou a missão no fluxo de desenvolvimento.',
+          createdAtIso: '2024-06-10T12:05:00.000Z',
+        },
+        {
+          id: 'history-flow-analytics-attachment-briefing',
+          kind: 'attachment_added',
+          actor: 'Aline Santos',
+          summary: 'briefing-narrativas-analytics.pdf anexado',
+          description: 'Documento de apoio compartilhado com o squad.',
+          createdAtIso: '2024-06-10T15:30:00.000Z',
+        },
+        {
+          id: 'history-flow-analytics-comment-helena',
+          kind: 'comment_added',
+          actor: 'Helena Pires',
+          summary: 'Helena Pires comentou na missão',
+          description:
+            'Atualizei os dashboards com métricas recentes e solicitei revisão para Aline Santos.',
+          createdAtIso: '2024-06-11T13:15:00.000Z',
+        },
+        {
+          id: 'history-flow-analytics-reply-aline',
+          kind: 'reply_added',
+          actor: 'Aline Santos',
+          summary: 'Aline Santos respondeu ao comentário de Helena Pires',
+          description: 'Confirmou revisão e prometeu anexar highlights para o squad.',
+          createdAtIso: '2024-06-11T14:42:00.000Z',
+        },
+        {
+          id: 'history-flow-analytics-comment-iuri',
+          kind: 'comment_updated',
+          actor: 'Iuri Paiva',
+          summary: 'Iuri Paiva editou um comentário',
+          description: 'Ajustou microcópias dos tooltips após feedback.',
+          createdAtIso: '2024-06-12T10:10:00.000Z',
+        },
+      ],
     },
     {
       id: 'story-avatars',
@@ -232,6 +332,55 @@ export class BoardState {
         },
       ],
       dueDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 3).toISOString(),
+      comments: [
+        {
+          id: 'comment-avatars-sync',
+          author: 'Diego Martins',
+          authorInitials: 'DM',
+          message:
+            'Programei o handshake inicial para sincronização. @Helena Pires consegue validar o fluxo?',
+          createdAtIso: '2024-06-09T16:20:00.000Z',
+          mentions: ['Helena Pires'],
+          isEdited: false,
+          replies: [],
+        },
+      ],
+      attachments: [
+        {
+          id: 'attachment-avatars-sync',
+          fileName: 'sync-diagrama-v1.drawio',
+          fileSizeLabel: '860 KB',
+          uploadedBy: 'Diego Martins',
+          uploadedAtIso: '2024-06-09T15:50:00.000Z',
+          downloadUrl: '#',
+        },
+      ],
+      history: [
+        {
+          id: 'history-avatars-created',
+          kind: 'status_change',
+          actor: 'Diego Martins',
+          summary: 'História criada em Pronto para iniciar',
+          description: 'Diego Martins posicionou o épico no quadro para pareamento.',
+          createdAtIso: '2024-06-07T11:05:00.000Z',
+        },
+        {
+          id: 'history-avatars-comment-diego',
+          kind: 'comment_added',
+          actor: 'Diego Martins',
+          summary: 'Diego Martins comentou sobre sincronização',
+          description: 'Solicitou validação do fluxo em tempo real para Helena Pires.',
+          createdAtIso: '2024-06-09T16:20:00.000Z',
+        },
+        {
+          id: 'history-avatars-attachment-sync',
+          kind: 'attachment_added',
+          actor: 'Diego Martins',
+          summary: 'sync-diagrama-v1.drawio anexado',
+          description: 'Blueprint inicial do protocolo de sincronização cooperativa.',
+          createdAtIso: '2024-06-09T15:50:00.000Z',
+        },
+      ],
     },
     {
       id: 'story-mission-engine',
@@ -264,6 +413,35 @@ export class BoardState {
           id: 'task-mission-engine-tests',
           title: 'Cobrir fluxo com testes automatizados',
           isDone: true,
+        },
+      ],
+      comments: [],
+      attachments: [
+        {
+          id: 'attachment-mission-engine-api',
+          fileName: 'api-contract-missions.yaml',
+          fileSizeLabel: '42 KB',
+          uploadedBy: 'Helena Pires',
+          uploadedAtIso: '2024-06-08T10:12:00.000Z',
+          downloadUrl: '#',
+        },
+      ],
+      history: [
+        {
+          id: 'history-mission-engine-created',
+          kind: 'status_change',
+          actor: 'Helena Pires',
+          summary: 'História criada em Revisão de código',
+          description: 'Helena abriu merge request para revisão colaborativa.',
+          createdAtIso: '2024-06-08T10:10:00.000Z',
+        },
+        {
+          id: 'history-mission-engine-attachment',
+          kind: 'attachment_added',
+          actor: 'Helena Pires',
+          summary: 'api-contract-missions.yaml anexado',
+          description: 'Contrato da API compartilhado com o squad de plataforma.',
+          createdAtIso: '2024-06-08T10:12:00.000Z',
         },
       ],
     },
@@ -310,6 +488,18 @@ export class BoardState {
           isDone: false,
         },
       ],
+      comments: [],
+      attachments: [],
+      history: [
+        {
+          id: 'history-cfd-created',
+          kind: 'status_change',
+          actor: 'Iuri Paiva',
+          summary: 'História criada em Release',
+          description: 'Iuri sinalizou que o CFD está preparado para hand-off.',
+          createdAtIso: '2024-06-06T09:45:00.000Z',
+        },
+      ],
     },
     {
       id: 'story-team-buffs',
@@ -347,6 +537,18 @@ export class BoardState {
           id: 'task-team-buffs-validation',
           title: 'Rodar sessão de validação com chapter agile',
           isDone: false,
+        },
+      ],
+      comments: [],
+      attachments: [],
+      history: [
+        {
+          id: 'history-team-buffs-created',
+          kind: 'status_change',
+          actor: 'Clara Sato',
+          summary: 'História criada em Backlog',
+          description: 'Clara adicionou a iniciativa para priorização colaborativa.',
+          createdAtIso: '2024-06-05T13:30:00.000Z',
         },
       ],
     },
@@ -388,8 +590,39 @@ export class BoardState {
           isDone: true,
         },
       ],
+      comments: [],
+      attachments: [
+        {
+          id: 'attachment-onboarding-guide',
+          fileName: 'guia-onboarding-guilda.pdf',
+          fileSizeLabel: '980 KB',
+          uploadedBy: 'Rafael Lima',
+          uploadedAtIso: '2024-06-04T18:15:00.000Z',
+          downloadUrl: '#',
+        },
+      ],
+      history: [
+        {
+          id: 'history-onboarding-created',
+          kind: 'status_change',
+          actor: 'Rafael Lima',
+          summary: 'História criada em Concluída',
+          description: 'Rafael finalizou o onboarding gamificado e documentou aprendizados.',
+          createdAtIso: '2024-06-04T18:20:00.000Z',
+        },
+        {
+          id: 'history-onboarding-attachment',
+          kind: 'attachment_added',
+          actor: 'Rafael Lima',
+          summary: 'guia-onboarding-guilda.pdf anexado',
+          description: 'Manual de onboarding liberado para novos integrantes.',
+          createdAtIso: '2024-06-04T18:15:00.000Z',
+        },
+      ],
     },
   ]);
+
+  private readonly storySignals = new Map<string, Signal<Story | null>>();
 
   readonly features = this._features.asReadonly();
   readonly sprints = this._sprints.asReadonly();
@@ -526,6 +759,35 @@ export class BoardState {
     return this.toStoryDetailsViewModel(story);
   }
 
+  watchStory(storyId: string): Signal<Story | null> {
+    const existing = this.storySignals.get(storyId);
+    if (existing) {
+      return existing;
+    }
+
+    const storySignal = computed(() => this._stories().find((item) => item.id === storyId) ?? null);
+    this.storySignals.set(storyId, storySignal);
+    return storySignal;
+  }
+
+  updateStory(storyId: string, projector: (story: Story) => Story): Story | null {
+    let updated: Story | null = null;
+
+    this._stories.update((stories) =>
+      stories.map((story) => {
+        if (story.id !== storyId) {
+          return story;
+        }
+
+        const next = projector(story);
+        updated = next;
+        return next;
+      }),
+    );
+
+    return updated;
+  }
+
   createStory(draft: CreateStoryPayload): Story | null {
     const statusesById = this.getStatusesById();
     const nextStatus = statusesById.get(draft.statusId);
@@ -561,6 +823,8 @@ export class BoardState {
     const sprintId =
       draft.sprintId && this._sprints().some((sprint) => sprint.id === draft.sprintId) ? draft.sprintId : undefined;
 
+    const createdAtIso = new Date().toISOString();
+
     const newStory: Story = {
       id: this.createId('story'),
       featureId: draft.featureId,
@@ -574,6 +838,18 @@ export class BoardState {
       tasks,
       dueDate: draft.dueDate && draft.dueDate.length > 0 ? draft.dueDate : undefined,
       sprintId,
+      comments: [],
+      attachments: [],
+      history: [
+        {
+          id: this.createId('history'),
+          kind: 'status_change',
+          actor: assignee,
+          summary: `História criada em ${nextStatus.name}`,
+          description: `${assignee} iniciou a missão diretamente em ${nextStatus.name}.`,
+          createdAtIso: createdAtIso,
+        },
+      ],
     } satisfies Story;
 
     this._stories.update((stories) => [newStory, ...stories]);

--- a/src/app/features/board/state/board.models.ts
+++ b/src/app/features/board/state/board.models.ts
@@ -60,6 +60,68 @@ export interface StoryTaskDraft {
   readonly isDone: boolean;
 }
 
+export interface StoryAttachment {
+  readonly id: string;
+  readonly fileName: string;
+  readonly fileSizeLabel: string;
+  readonly uploadedBy: string;
+  readonly uploadedAtIso: string;
+  readonly downloadUrl: string;
+}
+
+export interface StoryCommentReply {
+  readonly id: string;
+  readonly author: string;
+  readonly authorInitials: string;
+  readonly message: string;
+  readonly createdAtIso: string;
+  readonly updatedAtIso?: string;
+  readonly mentions: readonly string[];
+  readonly isEdited: boolean;
+}
+
+export interface StoryComment extends StoryCommentReply {
+  readonly replies: readonly StoryCommentReply[];
+}
+
+export type StoryHistoryEventKind =
+  | 'status_change'
+  | 'comment_added'
+  | 'comment_updated'
+  | 'reply_added'
+  | 'attachment_added'
+  | 'attachment_removed';
+
+export interface StoryHistoryEvent {
+  readonly id: string;
+  readonly kind: StoryHistoryEventKind;
+  readonly actor: string;
+  readonly summary: string;
+  readonly description?: string;
+  readonly createdAtIso: string;
+}
+
+export interface CreateStoryCommentPayload {
+  readonly author: string;
+  readonly message: string;
+}
+
+export interface UpdateStoryCommentPayload {
+  readonly message: string;
+}
+
+export interface CreateStoryCommentReplyPayload {
+  readonly author: string;
+  readonly message: string;
+}
+
+export interface CreateStoryAttachmentPayload {
+  readonly fileName: string;
+  readonly fileSizeLabel: string;
+  readonly uploadedBy: string;
+  readonly downloadUrl?: string;
+}
+
 export interface CreateStoryPayload {
   readonly title: string;
   readonly featureId: string;
@@ -87,6 +149,9 @@ export interface Story {
   readonly tasks: readonly StoryTask[];
   readonly dueDate?: string;
   readonly sprintId?: string;
+  readonly comments: readonly StoryComment[];
+  readonly attachments: readonly StoryAttachment[];
+  readonly history: readonly StoryHistoryEvent[];
 }
 
 export interface Feature {

--- a/src/app/features/board/state/story-attachments.state.ts
+++ b/src/app/features/board/state/story-attachments.state.ts
@@ -1,0 +1,128 @@
+import { computed, inject, Injectable, Signal } from '@angular/core';
+import type {
+  CreateStoryAttachmentPayload,
+  Story,
+  StoryAttachment,
+  StoryHistoryEvent,
+} from './board.models';
+import { BoardState } from './board-state.service';
+
+@Injectable({ providedIn: 'root' })
+export class StoryAttachmentsState {
+  private readonly boardState = inject(BoardState);
+  private readonly attachmentSignals = new Map<string, Signal<readonly StoryAttachment[]>>();
+
+  attachmentsForStory(storyId: string): Signal<readonly StoryAttachment[]> {
+    const cached = this.attachmentSignals.get(storyId);
+    if (cached) {
+      return cached;
+    }
+
+    const storySignal = this.boardState.watchStory(storyId);
+    const attachmentsSignal = computed(() => storySignal()?.attachments ?? []);
+    this.attachmentSignals.set(storyId, attachmentsSignal);
+    return attachmentsSignal;
+  }
+
+  uploadAttachment(
+    storyId: string,
+    payload: CreateStoryAttachmentPayload,
+  ): StoryAttachment | null {
+    const fileName = payload.fileName.trim();
+    const fileSizeLabel = payload.fileSizeLabel.trim();
+    const uploadedBy = payload.uploadedBy.trim();
+    const downloadUrl = (payload.downloadUrl ?? '#').trim();
+
+    if (fileName.length < 3 || uploadedBy.length < 3 || fileSizeLabel.length === 0) {
+      return null;
+    }
+
+    const timestamp = new Date().toISOString();
+
+    const attachment: StoryAttachment = {
+      id: this.createId('attachment'),
+      fileName,
+      fileSizeLabel,
+      uploadedBy,
+      uploadedAtIso: timestamp,
+      downloadUrl: downloadUrl.length > 0 ? downloadUrl : '#',
+    };
+
+    let created: StoryAttachment | null = null;
+
+    this.boardState.updateStory(storyId, (story) => {
+      created = attachment;
+      const historyEvent = this.createHistoryEvent({
+        kind: 'attachment_added',
+        actor: uploadedBy,
+        summary: `${fileName} anexado`,
+        description: `${uploadedBy} compartilhou um novo recurso com o squad.`,
+        createdAtIso: timestamp,
+      });
+
+      return {
+        ...story,
+        attachments: [attachment, ...story.attachments],
+        history: [historyEvent, ...story.history],
+      } satisfies Story;
+    });
+
+    return created;
+  }
+
+  removeAttachment(storyId: string, attachmentId: string, actor: string): boolean {
+    const normalizedActor = actor.trim();
+    if (normalizedActor.length < 3) {
+      return false;
+    }
+
+    const timestamp = new Date().toISOString();
+    let removedAttachment: StoryAttachment | null = null;
+
+    this.boardState.updateStory(storyId, (story) => {
+      const nextAttachments = story.attachments.filter((attachment) => {
+        if (attachment.id !== attachmentId) {
+          return true;
+        }
+
+        removedAttachment = attachment;
+        return false;
+      });
+
+      if (removedAttachment === null) {
+        return story;
+      }
+
+      const historyEvent = this.createHistoryEvent({
+        kind: 'attachment_removed',
+        actor: normalizedActor,
+        summary: `${removedAttachment.fileName} removido`,
+        description: `${normalizedActor} removeu o anexo da missão.`,
+        createdAtIso: timestamp,
+      });
+
+      return {
+        ...story,
+        attachments: nextAttachments,
+        history: [historyEvent, ...story.history],
+      } satisfies Story;
+    });
+
+    return removedAttachment !== null;
+  }
+
+  private createHistoryEvent(event: Omit<StoryHistoryEvent, 'id'>): StoryHistoryEvent {
+    return {
+      ...event,
+      id: this.createId('history'),
+    } satisfies StoryHistoryEvent;
+  }
+
+  private createId(prefix: string): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return `${prefix}-${crypto.randomUUID()}`;
+    }
+
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+  }
+}

--- a/src/app/features/board/state/story-comments.state.ts
+++ b/src/app/features/board/state/story-comments.state.ts
@@ -1,0 +1,246 @@
+import { computed, inject, Injectable, Signal } from '@angular/core';
+import type {
+  CreateStoryCommentPayload,
+  CreateStoryCommentReplyPayload,
+  Story,
+  StoryComment,
+  StoryCommentReply,
+  StoryHistoryEvent,
+  UpdateStoryCommentPayload,
+} from './board.models';
+import { BoardState } from './board-state.service';
+
+@Injectable({ providedIn: 'root' })
+export class StoryCommentsState {
+  private readonly boardState = inject(BoardState);
+  private readonly commentSignals = new Map<string, Signal<readonly StoryComment[]>>();
+
+  commentsForStory(storyId: string): Signal<readonly StoryComment[]> {
+    const cached = this.commentSignals.get(storyId);
+    if (cached) {
+      return cached;
+    }
+
+    const storySignal = this.boardState.watchStory(storyId);
+    const commentsSignal = computed(() => storySignal()?.comments ?? []);
+    this.commentSignals.set(storyId, commentsSignal);
+    return commentsSignal;
+  }
+
+  addComment(storyId: string, payload: CreateStoryCommentPayload): StoryComment | null {
+    const author = payload.author.trim();
+    const message = payload.message.trim();
+    if (author.length < 3 || message.length < 3) {
+      return null;
+    }
+
+    const mentions = this.extractMentions(message);
+    const timestamp = new Date().toISOString();
+
+    const comment: StoryComment = {
+      id: this.createId('comment'),
+      author,
+      authorInitials: this.createInitials(author),
+      message,
+      createdAtIso: timestamp,
+      mentions,
+      isEdited: false,
+      replies: [],
+    };
+
+    let created: StoryComment | null = null;
+
+    this.boardState.updateStory(storyId, (story) => {
+      const historyEvent = this.createHistoryEvent({
+        kind: 'comment_added',
+        actor: comment.author,
+        summary: `${comment.author} comentou na missão`,
+        description:
+          mentions.length > 0
+            ? `Mencionou ${this.formatMentions(mentions)} em um novo comentário.`
+            : 'Abriu uma nova discussão na missão.',
+        createdAtIso: timestamp,
+      });
+
+      created = comment;
+      return {
+        ...story,
+        comments: [comment, ...story.comments],
+        history: [historyEvent, ...story.history],
+      } satisfies Story;
+    });
+
+    return created;
+  }
+
+  updateComment(
+    storyId: string,
+    commentId: string,
+    payload: UpdateStoryCommentPayload,
+  ): StoryComment | null {
+    const message = payload.message.trim();
+    if (message.length < 3) {
+      return null;
+    }
+
+    const mentions = this.extractMentions(message);
+    const timestamp = new Date().toISOString();
+
+    let updated: StoryComment | null = null;
+
+    this.boardState.updateStory(storyId, (story) => {
+      let hasChanged = false;
+      const nextComments = story.comments.map((comment) => {
+        if (comment.id !== commentId) {
+          return comment;
+        }
+
+        hasChanged = true;
+        const nextComment: StoryComment = {
+          ...comment,
+          message,
+          mentions,
+          updatedAtIso: timestamp,
+          isEdited: true,
+        } satisfies StoryComment;
+        updated = nextComment;
+        return nextComment;
+      });
+
+      if (!hasChanged || updated === null) {
+        return story;
+      }
+
+      const historyEvent = this.createHistoryEvent({
+        kind: 'comment_updated',
+        actor: updated.author,
+        summary: `${updated.author} editou um comentário`,
+        description:
+          mentions.length > 0
+            ? `Atualizou o comentário mencionando ${this.formatMentions(mentions)}.`
+            : 'Ajustou o contexto do comentário existente.',
+        createdAtIso: timestamp,
+      });
+
+      return {
+        ...story,
+        comments: nextComments,
+        history: [historyEvent, ...story.history],
+      } satisfies Story;
+    });
+
+    return updated;
+  }
+
+  replyToComment(
+    storyId: string,
+    commentId: string,
+    payload: CreateStoryCommentReplyPayload,
+  ): StoryCommentReply | null {
+    const author = payload.author.trim();
+    const message = payload.message.trim();
+    if (author.length < 3 || message.length < 3) {
+      return null;
+    }
+
+    const mentions = this.extractMentions(message);
+    const timestamp = new Date().toISOString();
+
+    const reply: StoryCommentReply = {
+      id: this.createId('reply'),
+      author,
+      authorInitials: this.createInitials(author),
+      message,
+      createdAtIso: timestamp,
+      mentions,
+      isEdited: false,
+    };
+
+    let created: StoryCommentReply | null = null;
+
+    this.boardState.updateStory(storyId, (story) => {
+      let hasChanged = false;
+      const nextComments = story.comments.map((comment) => {
+        if (comment.id !== commentId) {
+          return comment;
+        }
+
+        hasChanged = true;
+        created = reply;
+        return {
+          ...comment,
+          replies: [...comment.replies, reply],
+        } satisfies StoryComment;
+      });
+
+      if (!hasChanged || created === null) {
+        return story;
+      }
+
+      const historyEvent = this.createHistoryEvent({
+        kind: 'reply_added',
+        actor: reply.author,
+        summary: `${reply.author} respondeu a um comentário`,
+        description:
+          mentions.length > 0
+            ? `Incluiu ${this.formatMentions(mentions)} na resposta.`
+            : 'Iniciou um encadeamento na discussão.',
+        createdAtIso: timestamp,
+      });
+
+      return {
+        ...story,
+        comments: nextComments,
+        history: [historyEvent, ...story.history],
+      } satisfies Story;
+    });
+
+    return created;
+  }
+
+  private createHistoryEvent(event: Omit<StoryHistoryEvent, 'id'>): StoryHistoryEvent {
+    return {
+      ...event,
+      id: this.createId('history'),
+    } satisfies StoryHistoryEvent;
+  }
+
+  private formatMentions(mentions: readonly string[]): string {
+    return mentions
+      .map((mention) => `@${mention}`)
+      .filter((mention, index, all) => all.indexOf(mention) === index)
+      .join(', ');
+  }
+
+  private extractMentions(message: string): readonly string[] {
+    const mentionPattern = /@([A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ\s'-]*)/g;
+    const mentions = new Set<string>();
+    let match: RegExpExecArray | null;
+
+    while ((match = mentionPattern.exec(message)) !== null) {
+      const mention = match[1]?.trim();
+      if (mention && mention.length > 0) {
+        mentions.add(mention);
+      }
+    }
+
+    return [...mentions];
+  }
+
+  private createInitials(name: string): string {
+    return name
+      .split(' ')
+      .filter(Boolean)
+      .map((part) => part.at(0)?.toUpperCase() ?? '')
+      .join('')
+      .slice(0, 2);
+  }
+
+  private createId(prefix: string): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return `${prefix}-${crypto.randomUUID()}`;
+    }
+
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
+  }
+}


### PR DESCRIPTION
## Summary
- extend the board story model and initial state with comment, attachment, and history collections
- add StoryCommentsState and StoryAttachmentsState services that manage signal-based updates and append timeline entries
- expose accessible discussion widgets on the board and story detail pages with Material feedback and refreshed styling

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e2ccf854848333bc8a703082f28fc7