### PR TITLE
feat: add home overview route

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -58,11 +58,17 @@ export class AppComponent {
 
   readonly navItems: readonly ShellNavItem[] = [
     {
-      label: 'Quadro',
-      description: 'Visão geral das missões',
+      label: 'Central',
+      description: 'Missões e discussões do time',
       icon: 'dashboard',
       link: '/',
       exact: true,
+    },
+    {
+      label: 'Quadro',
+      description: 'Tarefas e histórias em andamento',
+      icon: 'view_kanban',
+      link: '/quadro',
     },
     {
       label: 'Sprints',
@@ -89,6 +95,11 @@ export class AppComponent {
       link: '/quadro/personalizar',
     },
   ];
+
+  constructor() {
+    // Trigger inicialização do estado de tema ao carregar a shell.
+    void this.themeState;
+  }
 
   toggleMenu(): void {
     this.isMenuOpen.update((isOpen) => !isOpen);

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,7 +4,7 @@ export const routes: Routes = [
   {
     path: '',
     loadChildren: () =>
-      import('./features/board/board.routes').then((m) => m.BOARD_ROUTES),
+      import('./features/home/home.routes').then((m) => m.HOME_ROUTES),
   },
   {
     path: 'perfil',
@@ -17,6 +17,11 @@ export const routes: Routes = [
       import('./features/board-customizer/board-customizer.routes').then(
         (m) => m.BOARD_CUSTOMIZER_ROUTES,
       ),
+  },
+  {
+    path: 'quadro',
+    loadChildren: () =>
+      import('./features/board/board.routes').then((m) => m.BOARD_ROUTES),
   },
   {
     path: 'features',

--- a/src/app/features/board/board.routes.ts
+++ b/src/app/features/board/board.routes.ts
@@ -14,6 +14,6 @@ export const BOARD_ROUTES: Routes = [
     loadComponent: () =>
       import('./pages/board.page').then((m) => m.BoardPageComponent),
     pathMatch: 'full',
-    title: 'Hero Kanban — Missões do Time',
+    title: 'Hero Kanban — Quadro de tarefas',
   },
 ];

--- a/src/app/features/board/pages/board.page.html
+++ b/src/app/features/board/pages/board.page.html
@@ -1,91 +1,20 @@
 <section class="board" aria-labelledby="board-heading">
-  <div class="board__overview">
-    <mat-card class="board__summary">
-      <mat-card-header>
-        <div mat-card-avatar class="board__summary-avatar">
-          <mat-icon fontSet="material-symbols-rounded">view_kanban</mat-icon>
-        </div>
-        <mat-card-title id="board-heading">Missões em andamento</mat-card-title>
-        <mat-card-subtitle>
-          Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.
-        </mat-card-subtitle>
-      </mat-card-header>
-
-      <mat-card-content>
-        <div class="board__summary-grid">
-          <div class="board__actions" role="group" aria-label="Ações rápidas do quadro">
-            <button type="button" mat-flat-button color="primary" (click)="openCreateStory()">
-              <mat-icon fontSet="material-symbols-rounded">add_circle</mat-icon>
-              Nova história
-            </button>
-            <button type="button" mat-stroked-button color="accent">
-              <mat-icon fontSet="material-symbols-rounded">playlist_add</mat-icon>
-              Nova tarefa
-            </button>
-          </div>
-
-          <div class="board__progress" role="status" aria-live="polite">
-            <mat-chip-set class="board__level-chip-set">
-              <mat-chip class="board__level-chip" color="primary" selected>
-                <mat-icon matChipAvatar fontSet="material-symbols-rounded">workspace_premium</mat-icon>
-                Guilda nível {{ summary().level }}
-              </mat-chip>
-            </mat-chip-set>
-            <mat-progress-bar mode="determinate" [value]="summary().xpProgressPercent"></mat-progress-bar>
-            <p>
-              {{ summary().xpEarned }} XP acumulado · faltam {{ summary().xpToNextLevel }} XP para o próximo emblema
-            </p>
-          </div>
-
-          <mat-divider class="board__divider"></mat-divider>
-
-          <div class="board__stats">
-            <mat-chip-set>
-              <mat-chip class="board__stats-chip" color="primary" selected>
-                <mat-icon matChipAvatar fontSet="material-symbols-rounded">task_alt</mat-icon>
-                Histórias concluídas: {{ summary().completedStories }}
-              </mat-chip>
-              <mat-chip class="board__stats-chip" color="primary" selected>
-                <mat-icon matChipAvatar fontSet="material-symbols-rounded">hub</mat-icon>
-                Features ativas: {{ summary().activeFeatures }}
-              </mat-chip>
-              <mat-chip class="board__stats-chip" color="primary" selected>
-                <mat-icon matChipAvatar fontSet="material-symbols-rounded">monitoring</mat-icon>
-                Throughput semanal: {{ summary().weeklyThroughput }}
-              </mat-chip>
-            </mat-chip-set>
-          </div>
-        </div>
-      </mat-card-content>
-    </mat-card>
-
-    <mat-card *ngIf="summary().missions.length > 0" class="board__missions" aria-label="Missões em destaque">
-      <mat-card-header>
-        <mat-card-title>Missões</mat-card-title>
-        <mat-card-subtitle>Objetivos que destravam recompensas extras para a guilda.</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="board__missions-list">
-          <article class="mission" *ngFor="let mission of summary().missions">
-            <div class="mission__info">
-              <mat-icon aria-hidden="true" fontSet="material-symbols-rounded">auto_awesome</mat-icon>
-              <div>
-                <p class="mission__title">{{ mission.title }}</p>
-                <p class="mission__target">{{ mission.target }}</p>
-              </div>
-            </div>
-            <span class="mission__reward">{{ mission.reward }}</span>
-            <mat-progress-bar
-              class="mission__progress"
-              mode="determinate"
-              [value]="mission.progress * 100"
-              [attr.aria-label]="'Progresso ' + (mission.progress * 100 | number: '1.0-0') + '%'"
-            ></mat-progress-bar>
-          </article>
-        </div>
-      </mat-card-content>
-    </mat-card>
-  </div>
+  <header class="board__header">
+    <div class="board__heading">
+      <h1 id="board-heading">Quadro de tarefas</h1>
+      <p>Organize histórias e tarefas em andamento com limites claros por etapa.</p>
+    </div>
+    <div class="board__header-actions" role="group" aria-label="Ações do quadro">
+      <button type="button" mat-flat-button color="primary" (click)="openCreateStory()">
+        <mat-icon fontSet="material-symbols-rounded">add_circle</mat-icon>
+        Nova história
+      </button>
+      <button type="button" mat-stroked-button color="accent">
+        <mat-icon fontSet="material-symbols-rounded">playlist_add</mat-icon>
+        Nova tarefa
+      </button>
+    </div>
+  </header>
 
   <section class="board__toolbar" aria-label="Filtros das tarefas">
     <div class="board__filters" role="region" aria-label="Filtrar tarefas por sprint">
@@ -99,106 +28,6 @@
       </mat-form-field>
     </div>
   </section>
-
-  <mat-card class="board__conversations" aria-label="Discussões recentes do quadro">
-    <mat-card-header>
-      <mat-card-title>Discussões recentes</mat-card-title>
-      <mat-card-subtitle>Mantenha a guilda informada e destaque menções críticas.</mat-card-subtitle>
-    </mat-card-header>
-
-    <mat-card-content>
-      <section class="board__conversation-form" aria-label="Publicar novo comentário rápido">
-        <form
-          class="board__conversation-form-fields"
-          [formGroup]="quickCommentForm"
-          (ngSubmit)="onSubmitQuickComment()"
-          aria-describedby="board-conversation-hint"
-          novalidate
-        >
-          <div class="board__conversation-row">
-            <mat-form-field appearance="fill">
-              <mat-label>História</mat-label>
-              <mat-select formControlName="storyId" required aria-required="true">
-                <mat-option *ngFor="let option of storyOptions()" [value]="option.id">
-                  {{ option.title }}
-                </mat-option>
-              </mat-select>
-            </mat-form-field>
-
-            <mat-form-field appearance="fill">
-              <mat-label>Autor</mat-label>
-              <input
-                matInput
-                type="text"
-                formControlName="author"
-                required
-                aria-required="true"
-                placeholder="Nome de quem publica"
-              />
-              <mat-hint id="board-conversation-hint">Use &#64; para mencionar colegas e ativar alertas.</mat-hint>
-            </mat-form-field>
-          </div>
-
-          <mat-form-field appearance="fill" class="board__conversation-message">
-            <mat-label>Mensagem</mat-label>
-            <textarea
-              matInput
-              formControlName="message"
-              rows="3"
-              required
-              aria-required="true"
-              placeholder="Compartilhe atualizações e menções relevantes"
-            ></textarea>
-          </mat-form-field>
-
-          <div class="board__conversation-actions">
-            <button type="submit" mat-flat-button color="primary">
-              <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">send</mat-icon>
-              Publicar atualização
-            </button>
-          </div>
-        </form>
-      </section>
-
-      <section class="board__conversation-thread" aria-label="Comentários mais recentes">
-        <ol *ngIf="recentComments().length > 0; else emptyComments" class="board__comment-list">
-          <li
-            *ngFor="let entry of recentComments(); trackBy: trackRecentComment"
-            class="board__comment-item"
-          >
-            <article>
-              <header class="board__comment-header">
-                <span class="board__comment-author">{{ entry.comment.author }}</span>
-                <span class="board__comment-story">
-                  {{ entry.storyTitle }} ·
-                  <time [attr.datetime]="entry.comment.createdAtIso">
-                    {{ entry.comment.createdAtIso | date: 'short' }}
-                  </time>
-                </span>
-              </header>
-              <p class="board__comment-message">{{ entry.comment.message }}</p>
-              <div
-                *ngIf="entry.comment.mentions.length > 0"
-                class="board__comment-mentions"
-                aria-label="Menções registradas"
-              >
-                <mat-chip-set>
-                  <mat-chip *ngFor="let mention of entry.comment.mentions" color="primary" selected>
-                    &#64;{{ mention }}
-                  </mat-chip>
-                </mat-chip-set>
-              </div>
-            </article>
-          </li>
-        </ol>
-        <ng-template #emptyComments>
-          <p class="board__comment-empty" role="status">
-            Ainda não temos conversas registradas aqui. Que tal iniciar uma atualização para o squad?
-          </p>
-        </ng-template>
-      </section>
-    </mat-card-content>
-  </mat-card>
 
   <section class="board__columns" role="list">
     <kanban-board-column

--- a/src/app/features/board/pages/board.page.scss
+++ b/src/app/features/board/pages/board.page.scss
@@ -10,88 +10,40 @@
   color: var(--hk-text-primary);
 }
 
-.board__overview {
-  display: grid;
-  gap: clamp(1.25rem, 3vw, 2rem);
+.board__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-inline: clamp(0.5rem, 4vw, 2.25rem);
 }
 
-.board__definition {
-  margin: 0;
-  padding: 0.9rem 1.25rem;
-  border-radius: 1rem;
-  background: var(--hk-success-soft);
-  border: 1px solid var(--hk-success-border);
-  color: var(--hk-text-secondary);
-  line-height: 1.6;
-}
-
-.board__definition > strong {
-  color: var(--hk-text-primary);
-}
-
-@media (min-width: 1120px) {
-  .board__overview {
-    grid-template-columns: minmax(0, 2.15fr) minmax(0, 1.35fr);
-    align-items: stretch;
+@media (min-width: 960px) {
+  .board__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 }
 
-.board__summary {
-  background: var(--hk-surface);
-  border: 1px solid var(--hk-border);
-  box-shadow: 0 24px 40px -18px rgba(var(--hk-accent-strong-rgb), 0.35);
-  border-radius: 1.25rem;
-  overflow: hidden;
+.board__heading > h1 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
 }
 
-.board__summary-avatar {
-  display: grid;
-  place-items: center;
-  background: rgba(var(--hk-accent-rgb), 0.22);
-  color: var(--hk-text-primary);
+.board__heading > p {
+  margin: 0;
+  color: var(--hk-text-muted);
+  max-width: 48ch;
 }
 
-.board__summary-grid {
-  display: grid;
-  gap: clamp(1rem, 2.5vw, 1.75rem);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  align-items: stretch;
-}
-
-.board__summary :is(.mat-mdc-card-header, .mat-mdc-card-content) {
-  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
-}
-
-.board__summary .mat-mdc-card-header {
-  padding-block: clamp(1.25rem, 3vw, 1.75rem) 1.25rem;
-  gap: 1rem;
-  align-items: center;
-}
-
-.board__summary .mat-mdc-card-content {
-  padding-bottom: clamp(1.5rem, 4vw, 2.5rem);
-}
-
-.board__summary .mat-mdc-card-avatar {
-  width: 3.25rem;
-  height: 3.25rem;
-  border-radius: 1rem;
-}
-
-.board__actions {
+.board__header-actions {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
-@media (min-width: 720px) {
-  .board__actions {
-    flex-direction: row;
-  }
-}
-
-.board__actions button[mat-flat-button],
-.board__actions button[mat-stroked-button] {
+.board__header-actions button[mat-flat-button],
+.board__header-actions button[mat-stroked-button] {
   min-height: 3rem;
   padding-inline: 1.25rem;
   font-weight: 600;
@@ -100,106 +52,6 @@
   align-items: center;
   gap: 0.5rem;
 }
-
-.board__progress {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.board__progress mat-progress-bar {
-  --mdc-linear-progress-track-thickness: 0.65rem;
-  border-radius: 999px;
-}
-
-.board__level-chip-set {
-  display: inline-flex;
-}
-
-.board__level-chip {
-  --mdc-chip-container-color: var(--hk-chip-primary-background);
-  --mdc-chip-elevated-container-color: var(--hk-chip-primary-background);
-  --mdc-chip-label-text-color: var(--hk-chip-primary-text);
-  --mdc-chip-selected-label-text-color: var(--hk-chip-primary-text);
-  --mdc-chip-with-icon-icon-color: var(--hk-chip-primary-text);
-  --mdc-chip-outline-color: var(--hk-chip-primary-border);
-  --mdc-chip-focus-outline-color: var(--hk-chip-primary-focus);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding-inline: 0.85rem;
-  background: var(--hk-chip-primary-background);
-  color: var(--hk-chip-primary-text);
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
-
-  &:hover,
-  &:focus-visible {
-    background: var(--hk-chip-primary-hover);
-    border-color: var(--hk-chip-primary-focus);
-    box-shadow: 0 0 0 1px var(--hk-chip-primary-focus);
-  }
-}
-
-.board__progress > p {
-  margin: 0;
-  color: var(--hk-text-muted);
-}
-
-.board__divider {
-  display: none;
-}
-
-@media (min-width: 960px) {
-  .board__divider {
-    display: block;
-    grid-column: 1 / -1;
-  }
-}
-
-.board__stats mat-chip-set {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.board__stats mat-chip {
-  padding-inline: 0.85rem;
-  height: auto;
-  min-height: 2.5rem;
-  font-weight: 500;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-}
-
-.board__stats-chip {
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  --mdc-chip-container-color: var(--hk-accent-soft);
-  --mdc-chip-elevated-container-color: var(--hk-accent-soft);
-  --mdc-chip-label-text-color: var(--hk-text-primary);
-  --mdc-chip-selected-label-text-color: var(--hk-text-primary);
-  --mdc-chip-with-icon-icon-color: var(--hk-text-primary);
-  --mdc-chip-outline-color: rgba(var(--hk-accent-strong-rgb), 0.35);
-  --mdc-chip-focus-outline-color: rgba(var(--hk-accent-strong-rgb), 0.55);
-  --mdc-chip-hover-state-layer-color: rgba(var(--hk-accent-rgb), 0.3);
-  --mdc-chip-focus-state-layer-color: rgba(var(--hk-accent-rgb), 0.35);
-  background: var(--hk-accent-soft);
-  color: var(--hk-text-primary);
-  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
-}
-
-.board__stats-chip mat-icon {
-  color: currentColor;
-}
-
-.board__stats-chip:focus-visible,
-.board__stats-chip:hover {
-  background: rgba(var(--hk-accent-rgb), 0.22);
-  box-shadow: 0 0 0 1px rgba(var(--hk-accent-strong-rgb), 0.5);
-}
-
 
 .board__toolbar {
   display: flex;
@@ -218,78 +70,6 @@
   --mat-form-field-container-height: 3.1rem;
   --mdc-filled-text-field-container-shape: 1rem;
   --mdc-outlined-text-field-container-shape: 1rem;
-}
-
-.board__missions {
-  background: var(--hk-surface);
-  border: 1px solid var(--hk-border);
-  border-radius: 1.25rem;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.board__missions :is(.mat-mdc-card-header, .mat-mdc-card-content) {
-  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
-}
-
-.board__missions .mat-mdc-card-header {
-  padding-block: clamp(1.25rem, 3vw, 1.75rem) 1rem;
-  gap: 0.75rem;
-}
-
-.board__missions .mat-mdc-card-content {
-  padding-bottom: clamp(1.25rem, 4vw, 2.25rem);
-  display: grid;
-  gap: 0.5rem;
-}
-
-.board__missions-list {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.mission {
-  display: grid;
-  gap: 0.5rem;
-  padding: 0.75rem 0;
-  border-bottom: 1px solid var(--hk-border);
-}
-
-.mission:last-child {
-  border-bottom: none;
-}
-
-.mission__info {
-  display: flex;
-  gap: 0.75rem;
-  align-items: flex-start;
-}
-
-.mission__info mat-icon {
-  font-size: 1.75rem;
-  color: var(--hk-accent);
-}
-
-.mission__title {
-  margin: 0;
-  font-weight: 600;
-}
-
-.mission__target {
-  margin: 0;
-  color: var(--hk-text-muted);
-  font-size: 0.9rem;
-}
-
-.mission__reward {
-  font-weight: 600;
-  color: var(--hk-success);
-}
-
-.mission__progress {
-  --mdc-linear-progress-track-thickness: 0.6rem;
-  border-radius: 999px;
 }
 
 .board__columns {
@@ -314,114 +94,4 @@
 .board__columns::-webkit-scrollbar-thumb {
   background: rgba(var(--hk-accent-strong-rgb), 0.35);
   border-radius: 999px;
-}
-
-.board__conversations {
-  background: var(--hk-surface);
-  border: 1px solid var(--hk-border);
-  border-radius: 1.25rem;
-  box-shadow: 0 24px 48px -24px rgba(var(--hk-accent-strong-rgb), 0.45);
-  margin-inline: clamp(0.5rem, 2vw, 1.25rem);
-}
-
-.board__conversations .mat-mdc-card-header,
-.board__conversations .mat-mdc-card-content {
-  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
-}
-
-.board__conversation-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.board__conversation-form-fields {
-  display: grid;
-  gap: 1rem;
-}
-
-.board__conversation-row {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.board__conversation-message {
-  width: 100%;
-}
-
-.board__conversation-actions {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.board__conversation-actions button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  border-radius: 999px;
-}
-
-.board__conversation-thread {
-  display: grid;
-  gap: 1rem;
-}
-
-.board__comment-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 1rem;
-}
-
-.board__comment-item {
-  background: color-mix(in srgb, var(--hk-surface-elevated) 75%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hk-border) 85%, transparent);
-  border-radius: 1rem;
-  padding: 1rem 1.25rem;
-}
-
-.board__comment-header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: baseline;
-  margin-bottom: 0.5rem;
-}
-
-.board__comment-author {
-  font-weight: 700;
-  color: var(--hk-text-primary);
-}
-
-.board__comment-story {
-  color: var(--hk-text-muted);
-  font-size: 0.85rem;
-}
-
-.board__comment-message {
-  margin: 0;
-  color: var(--hk-text-secondary);
-  line-height: 1.5;
-}
-
-.board__comment-mentions {
-  margin-top: 0.75rem;
-}
-
-.board__comment-mentions mat-chip-set {
-  gap: 0.35rem;
-}
-
-.board__comment-empty {
-  margin: 0;
-  color: var(--hk-text-muted);
-  background: color-mix(in srgb, var(--hk-accent) 12%, transparent);
-  border: 1px dashed color-mix(in srgb, var(--hk-accent-strong) 35%, transparent);
-  border-radius: 1rem;
-  padding: 1rem 1.5rem;
-  text-align: center;
 }

--- a/src/app/features/board/pages/board.page.ts
+++ b/src/app/features/board/pages/board.page.ts
@@ -1,29 +1,15 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
-import { DatePipe, DecimalPipe, NgFor, NgIf } from '@angular/common';
-import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { NgFor } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
-import { MatCardModule } from '@angular/material/card';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatDividerModule } from '@angular/material/divider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatOptionModule } from '@angular/material/core';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSelectModule } from '@angular/material/select';
-import { MatInputModule } from '@angular/material/input';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 
-import type { BoardColumnViewModel, CreateStoryPayload, StoryComment } from '../state/board.models';
+import type { BoardColumnViewModel, CreateStoryPayload } from '../state/board.models';
 import { BoardState } from '../state/board-state.service';
 import { BoardColumnComponent } from '../components/board-column/board-column.component';
 import { CreateStoryModalComponent } from '../components/create-story-modal/create-story-modal.component';
-import { StoryCommentsState } from '../state/story-comments.state';
-
-interface RecentComment {
-  readonly storyId: string;
-  readonly storyTitle: string;
-  readonly comment: StoryComment;
-}
 
 @Component({
   selector: 'hk-board-page',
@@ -33,97 +19,28 @@ interface RecentComment {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgFor,
-    NgIf,
-    DecimalPipe,
-    DatePipe,
     BoardColumnComponent,
     CreateStoryModalComponent,
     MatButtonModule,
     MatIconModule,
-    MatCardModule,
-    MatProgressBarModule,
-    MatChipsModule,
     MatFormFieldModule,
     MatSelectModule,
     MatOptionModule,
-    MatDividerModule,
-    MatInputModule,
-    MatSnackBarModule,
-    ReactiveFormsModule,
   ],
 })
 export class BoardPageComponent {
   private readonly boardState = inject(BoardState);
-  private readonly commentsState = inject(StoryCommentsState);
-  private readonly snackBar = inject(MatSnackBar);
-  private readonly formBuilder = inject(NonNullableFormBuilder);
 
   protected readonly columns = this.boardState.columns;
-  protected readonly summary = this.boardState.summary;
   protected readonly features = this.boardState.features;
   protected readonly sprints = this.boardState.sprints;
   protected readonly statusOptions = this.boardState.statusOptions;
   protected readonly sprintOptions = this.boardState.sprintFilterOptions;
   protected readonly selectedSprintId = this.boardState.selectedSprintId;
   protected readonly isCreatingStory = signal(false);
-  protected readonly storyOptions = computed(() =>
-    this.boardState
-      .stories()
-      .map((story) => ({ id: story.id, title: story.title, assignee: story.assignee })),
-  );
-
-  protected readonly recentComments = computed<readonly RecentComment[]>(() => {
-    return this.boardState
-      .stories()
-      .flatMap((story) =>
-        story.comments.map(
-          (comment) =>
-            ({
-              storyId: story.id,
-              storyTitle: story.title,
-              comment,
-            }) satisfies RecentComment,
-        ),
-      )
-      .sort((a, b) => Date.parse(b.comment.createdAtIso) - Date.parse(a.comment.createdAtIso))
-      .slice(0, 4);
-  });
-
-  protected readonly quickCommentForm = this.formBuilder.group({
-    storyId: this.formBuilder.control('', Validators.required),
-    author: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
-    message: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
-  });
-
-  private readonly hydrateFormDefaults = effect(
-    () => {
-      const stories = this.boardState.stories();
-      if (stories.length === 0) {
-        return;
-      }
-
-      const currentStoryId = this.quickCommentForm.controls.storyId.value;
-      if (!currentStoryId || !stories.some((story) => story.id === currentStoryId)) {
-        this.quickCommentForm.controls.storyId.setValue(stories[0]?.id ?? '');
-      }
-
-      const currentAuthor = this.quickCommentForm.controls.author.value;
-      if (currentAuthor.length === 0) {
-        const defaultAssignee = stories.find((story) => story.id === this.quickCommentForm.controls.storyId.value)?.assignee;
-        if (defaultAssignee) {
-          this.quickCommentForm.controls.author.setValue(defaultAssignee);
-        }
-      }
-    },
-    { allowSignalWrites: true },
-  );
 
   protected trackColumn(_: number, column: BoardColumnViewModel): string {
     return column.status.id;
-  }
-
-  protected trackRecentComment(_: number, entry: RecentComment): string {
-    return entry.comment.id;
   }
 
   protected openCreateStory(): void {
@@ -143,42 +60,5 @@ export class BoardPageComponent {
 
   protected onSprintFilterSelected(sprintId: string): void {
     this.boardState.setSprintFilter(sprintId);
-  }
-
-  protected onSubmitQuickComment(): void {
-    if (this.quickCommentForm.invalid) {
-      this.quickCommentForm.markAllAsTouched();
-      return;
-    }
-
-    const value = this.quickCommentForm.getRawValue();
-    const created = this.commentsState.addComment(value.storyId, {
-      author: value.author,
-      message: value.message,
-    });
-
-    if (!created) {
-      this.snackBar.open('Não foi possível registrar o comentário. Confira os campos e tente novamente.', 'Fechar', {
-        duration: 4000,
-      });
-      return;
-    }
-
-    this.quickCommentForm.controls.message.setValue('');
-    this.quickCommentForm.controls.message.markAsPristine();
-    this.quickCommentForm.controls.message.markAsUntouched();
-
-    const storyTitle = this.storyOptions().find((option) => option.id === value.storyId)?.title ?? 'história selecionada';
-    if (created.mentions.length > 0) {
-      this.snackBar.open(
-        `Menção enviada para ${created.mentions.join(', ')} em ${storyTitle}.`,
-        'Ok',
-        { duration: 5000 },
-      );
-    } else {
-      this.snackBar.open(`Comentário publicado em ${storyTitle}.`, 'Ok', {
-        duration: 3500,
-      });
-    }
   }
 }

--- a/src/app/features/home/home.routes.ts
+++ b/src/app/features/home/home.routes.ts
@@ -1,0 +1,11 @@
+import { Routes } from '@angular/router';
+
+export const HOME_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./pages/home.page').then((m) => m.HomePageComponent),
+    pathMatch: 'full',
+    title: 'Hero Kanban — Missões do Time',
+  },
+];

--- a/src/app/features/home/pages/home.page.html
+++ b/src/app/features/home/pages/home.page.html
@@ -1,0 +1,182 @@
+<section class="home" aria-labelledby="home-heading">
+  <div class="home__overview">
+    <mat-card class="home__summary">
+      <mat-card-header>
+        <div mat-card-avatar class="home__summary-avatar">
+          <mat-icon fontSet="material-symbols-rounded">view_kanban</mat-icon>
+        </div>
+        <mat-card-title id="home-heading">Missões em andamento</mat-card-title>
+        <mat-card-subtitle>
+          Visual moderno, métricas avançadas e recompensas compartilhadas para manter o squad engajado.
+        </mat-card-subtitle>
+      </mat-card-header>
+
+      <mat-card-content>
+        <div class="home__summary-grid">
+          <div class="home__actions" role="group" aria-label="Ações rápidas do quadro">
+            <a mat-flat-button color="primary" routerLink="/quadro">
+              <mat-icon fontSet="material-symbols-rounded">add_circle</mat-icon>
+              Nova história
+            </a>
+            <a mat-stroked-button color="accent" routerLink="/quadro">
+              <mat-icon fontSet="material-symbols-rounded">playlist_add</mat-icon>
+              Nova tarefa
+            </a>
+          </div>
+
+          <div class="home__progress" role="status" aria-live="polite">
+            <mat-chip-set class="home__level-chip-set">
+              <mat-chip class="home__level-chip" color="primary" selected>
+                <mat-icon matChipAvatar fontSet="material-symbols-rounded">workspace_premium</mat-icon>
+                Guilda nível {{ summary().level }}
+              </mat-chip>
+            </mat-chip-set>
+            <mat-progress-bar mode="determinate" [value]="summary().xpProgressPercent"></mat-progress-bar>
+            <p>
+              {{ summary().xpEarned }} XP acumulado · faltam {{ summary().xpToNextLevel }} XP para o próximo emblema
+            </p>
+          </div>
+
+          <mat-divider class="home__divider"></mat-divider>
+
+          <div class="home__stats">
+            <mat-chip-set>
+              <mat-chip class="home__stats-chip" color="primary" selected>
+                <mat-icon matChipAvatar fontSet="material-symbols-rounded">task_alt</mat-icon>
+                Histórias concluídas: {{ summary().completedStories }}
+              </mat-chip>
+              <mat-chip class="home__stats-chip" color="primary" selected>
+                <mat-icon matChipAvatar fontSet="material-symbols-rounded">hub</mat-icon>
+                Features ativas: {{ summary().activeFeatures }}
+              </mat-chip>
+              <mat-chip class="home__stats-chip" color="primary" selected>
+                <mat-icon matChipAvatar fontSet="material-symbols-rounded">monitoring</mat-icon>
+                Throughput semanal: {{ summary().weeklyThroughput }}
+              </mat-chip>
+            </mat-chip-set>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card *ngIf="summary().missions.length > 0" class="home__missions" aria-label="Missões em destaque">
+      <mat-card-header>
+        <mat-card-title>Missões</mat-card-title>
+        <mat-card-subtitle>Objetivos que destravam recompensas extras para a guilda.</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="home__missions-list">
+          <article class="mission" *ngFor="let mission of summary().missions">
+            <div class="mission__info">
+              <mat-icon aria-hidden="true" fontSet="material-symbols-rounded">auto_awesome</mat-icon>
+              <div>
+                <p class="mission__title">{{ mission.title }}</p>
+                <p class="mission__target">{{ mission.target }}</p>
+              </div>
+            </div>
+            <span class="mission__reward">{{ mission.reward }}</span>
+            <mat-progress-bar
+              class="mission__progress"
+              mode="determinate"
+              [value]="mission.progress * 100"
+              [attr.aria-label]="'Progresso ' + (mission.progress * 100 | number: '1.0-0') + '%'"
+            ></mat-progress-bar>
+          </article>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+
+  <mat-card class="home__conversations" aria-label="Discussões recentes do quadro">
+    <mat-card-header>
+      <mat-card-title>Discussões recentes</mat-card-title>
+      <mat-card-subtitle>Mantenha a guilda informada e destaque menções críticas.</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      <section class="home__conversation-form" aria-label="Publicar novo comentário rápido">
+        <form
+          class="home__conversation-form-fields"
+          [formGroup]="quickCommentForm"
+          (ngSubmit)="onSubmitQuickComment()"
+          aria-describedby="home-conversation-hint"
+          novalidate
+        >
+          <div class="home__conversation-row">
+            <mat-form-field appearance="fill">
+              <mat-label>História</mat-label>
+              <mat-select formControlName="storyId" required aria-required="true">
+                <mat-option *ngFor="let option of storyOptions()" [value]="option.id">
+                  {{ option.title }}
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
+
+            <mat-form-field appearance="fill">
+              <mat-label>Autor</mat-label>
+              <input
+                matInput
+                type="text"
+                formControlName="author"
+                required
+                aria-required="true"
+                placeholder="Nome de quem publica"
+              />
+              <mat-hint id="home-conversation-hint">Use &#64; para mencionar colegas e ativar alertas.</mat-hint>
+            </mat-form-field>
+          </div>
+
+          <mat-form-field appearance="fill" class="home__conversation-message">
+            <mat-label>Mensagem</mat-label>
+            <textarea
+              matInput
+              formControlName="message"
+              rows="3"
+              required
+              aria-required="true"
+              placeholder="Compartilhe atualizações e menções relevantes"
+            ></textarea>
+          </mat-form-field>
+
+          <div class="home__conversation-actions">
+            <button type="submit" mat-flat-button color="primary">
+              <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">send</mat-icon>
+              Publicar atualização
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="home__conversation-thread" aria-label="Comentários mais recentes">
+        <ol *ngIf="recentComments().length > 0; else emptyComments" class="home__comment-list">
+          <li *ngFor="let entry of recentComments(); trackBy: trackRecentComment" class="home__comment-item">
+            <article>
+              <header class="home__comment-header">
+                <span class="home__comment-author">{{ entry.comment.author }}</span>
+                <span class="home__comment-story">
+                  {{ entry.storyTitle }} ·
+                  <time [attr.datetime]="entry.comment.createdAtIso">
+                    {{ entry.comment.createdAtIso | date: 'short' }}
+                  </time>
+                </span>
+              </header>
+              <p class="home__comment-message">{{ entry.comment.message }}</p>
+              <div *ngIf="entry.comment.mentions.length > 0" class="home__comment-mentions" aria-label="Menções registradas">
+                <mat-chip-set>
+                  <mat-chip *ngFor="let mention of entry.comment.mentions" color="primary" selected>
+                    &#64;{{ mention }}
+                  </mat-chip>
+                </mat-chip-set>
+              </div>
+            </article>
+          </li>
+        </ol>
+        <ng-template #emptyComments>
+          <p class="home__comment-empty" role="status">
+            Ainda não temos conversas registradas aqui. Que tal iniciar uma atualização para o squad?
+          </p>
+        </ng-template>
+      </section>
+    </mat-card-content>
+  </mat-card>
+</section>

--- a/src/app/features/home/pages/home.page.scss
+++ b/src/app/features/home/pages/home.page.scss
@@ -1,0 +1,368 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.home {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  color: var(--hk-text-primary);
+}
+
+.home__overview {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+@media (min-width: 1120px) {
+  .home__overview {
+    grid-template-columns: minmax(0, 2.15fr) minmax(0, 1.35fr);
+    align-items: stretch;
+  }
+}
+
+.home__summary {
+  background: var(--hk-surface);
+  border: 1px solid var(--hk-border);
+  box-shadow: 0 24px 40px -18px rgba(var(--hk-accent-strong-rgb), 0.35);
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.home__summary-avatar {
+  display: grid;
+  place-items: center;
+  background: rgba(var(--hk-accent-rgb), 0.22);
+  color: var(--hk-text-primary);
+}
+
+.home__summary-grid {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: stretch;
+}
+
+.home__summary :is(.mat-mdc-card-header, .mat-mdc-card-content) {
+  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.home__summary .mat-mdc-card-header {
+  padding-block: clamp(1.25rem, 3vw, 1.75rem) 1.25rem;
+  gap: 1rem;
+  align-items: center;
+}
+
+.home__summary .mat-mdc-card-content {
+  padding-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.home__summary .mat-mdc-card-avatar {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 1rem;
+}
+
+.home__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 720px) {
+  .home__actions {
+    flex-direction: row;
+  }
+}
+
+.home__actions :is(a[mat-flat-button], a[mat-stroked-button], button[mat-flat-button], button[mat-stroked-button]) {
+  min-height: 3rem;
+  padding-inline: 1.25rem;
+  font-weight: 600;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.home__progress {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.home__progress mat-progress-bar {
+  --mdc-linear-progress-track-thickness: 0.65rem;
+  border-radius: 999px;
+}
+
+.home__level-chip-set {
+  display: inline-flex;
+}
+
+.home__level-chip {
+  --mdc-chip-container-color: var(--hk-chip-primary-background);
+  --mdc-chip-elevated-container-color: var(--hk-chip-primary-background);
+  --mdc-chip-label-text-color: var(--hk-chip-primary-text);
+  --mdc-chip-selected-label-text-color: var(--hk-chip-primary-text);
+  --mdc-chip-with-icon-icon-color: var(--hk-chip-primary-text);
+  --mdc-chip-outline-color: var(--hk-chip-primary-border);
+  --mdc-chip-focus-outline-color: var(--hk-chip-primary-focus);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-inline: 0.85rem;
+  background: var(--hk-chip-primary-background);
+  color: var(--hk-chip-primary-text);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--hk-chip-primary-hover);
+    border-color: var(--hk-chip-primary-focus);
+    box-shadow: 0 0 0 1px var(--hk-chip-primary-focus);
+  }
+}
+
+.home__progress > p {
+  margin: 0;
+  color: var(--hk-text-muted);
+}
+
+.home__divider {
+  display: none;
+}
+
+@media (min-width: 960px) {
+  .home__divider {
+    display: block;
+    grid-column: 1 / -1;
+  }
+}
+
+.home__stats mat-chip-set {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.home__stats mat-chip {
+  padding-inline: 0.85rem;
+  height: auto;
+  min-height: 2.5rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.home__stats-chip {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  --mdc-chip-container-color: var(--hk-accent-soft);
+  --mdc-chip-elevated-container-color: var(--hk-accent-soft);
+  --mdc-chip-label-text-color: var(--hk-text-primary);
+  --mdc-chip-selected-label-text-color: var(--hk-text-primary);
+  --mdc-chip-with-icon-icon-color: var(--hk-text-primary);
+  --mdc-chip-outline-color: rgba(var(--hk-accent-strong-rgb), 0.35);
+  --mdc-chip-focus-outline-color: rgba(var(--hk-accent-strong-rgb), 0.55);
+  --mdc-chip-hover-state-layer-color: rgba(var(--hk-accent-rgb), 0.3);
+  --mdc-chip-focus-state-layer-color: rgba(var(--hk-accent-rgb), 0.35);
+  background: var(--hk-accent-soft);
+  color: var(--hk-text-primary);
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.home__stats-chip mat-icon {
+  color: currentColor;
+}
+
+.home__stats-chip:focus-visible,
+.home__stats-chip:hover {
+  background: rgba(var(--hk-accent-rgb), 0.22);
+  box-shadow: 0 0 0 1px rgba(var(--hk-accent-strong-rgb), 0.5);
+}
+
+.home__missions {
+  background: var(--hk-surface);
+  border: 1px solid var(--hk-border);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.home__missions :is(.mat-mdc-card-header, .mat-mdc-card-content) {
+  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.home__missions .mat-mdc-card-header {
+  padding-block: clamp(1.25rem, 3vw, 1.75rem) 1rem;
+  gap: 0.75rem;
+}
+
+.home__missions .mat-mdc-card-content {
+  padding-bottom: clamp(1.25rem, 4vw, 2.25rem);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.home__missions-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.mission {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--hk-border);
+}
+
+.mission:last-child {
+  border-bottom: none;
+}
+
+.mission__info {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.mission__info mat-icon {
+  font-size: 1.75rem;
+  color: var(--hk-accent);
+}
+
+.mission__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.mission__target {
+  margin: 0;
+  color: var(--hk-text-muted);
+  font-size: 0.9rem;
+}
+
+.mission__reward {
+  font-weight: 600;
+  color: var(--hk-success);
+}
+
+.mission__progress {
+  --mdc-linear-progress-track-thickness: 0.6rem;
+  border-radius: 999px;
+}
+
+.home__conversations {
+  background: var(--hk-surface);
+  border: 1px solid var(--hk-border);
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 48px -24px rgba(var(--hk-accent-strong-rgb), 0.45);
+  margin-inline: clamp(0.5rem, 2vw, 1.25rem);
+}
+
+.home__conversations .mat-mdc-card-header,
+.home__conversations .mat-mdc-card-content {
+  padding-inline: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.home__conversation-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.home__conversation-form-fields {
+  display: grid;
+  gap: 1rem;
+}
+
+.home__conversation-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.home__conversation-message {
+  width: 100%;
+}
+
+.home__conversation-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.home__conversation-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  border-radius: 999px;
+}
+
+.home__conversation-thread {
+  display: grid;
+  gap: 1rem;
+}
+
+.home__comment-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.home__comment-item {
+  background: color-mix(in srgb, var(--hk-surface-elevated) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 85%, transparent);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.home__comment-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+
+.home__comment-author {
+  font-weight: 700;
+  color: var(--hk-text-primary);
+}
+
+.home__comment-story {
+  color: var(--hk-text-muted);
+  font-size: 0.85rem;
+}
+
+.home__comment-message {
+  margin: 0;
+  color: var(--hk-text-secondary);
+  line-height: 1.5;
+}
+
+.home__comment-mentions {
+  margin-top: 0.75rem;
+}
+
+.home__comment-mentions mat-chip-set {
+  gap: 0.35rem;
+}
+
+.home__comment-empty {
+  margin: 0;
+  color: var(--hk-text-muted);
+  background: color-mix(in srgb, var(--hk-accent) 12%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--hk-accent-strong) 35%, transparent);
+  border-radius: 1rem;
+  padding: 1rem 1.5rem;
+  text-align: center;
+}

--- a/src/app/features/home/pages/home.page.ts
+++ b/src/app/features/home/pages/home.page.ts
@@ -1,0 +1,152 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
+import { DatePipe, DecimalPipe, NgFor, NgIf } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatOptionModule } from '@angular/material/core';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+import type { StoryComment } from '../../board/state/board.models';
+import { BoardState } from '../../board/state/board-state.service';
+import { StoryCommentsState } from '../../board/state/story-comments.state';
+
+interface RecentComment {
+  readonly storyId: string;
+  readonly storyTitle: string;
+  readonly comment: StoryComment;
+}
+
+@Component({
+  selector: 'hk-home-page',
+  standalone: true,
+  templateUrl: './home.page.html',
+  styleUrls: ['./home.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NgFor,
+    NgIf,
+    DecimalPipe,
+    DatePipe,
+    ReactiveFormsModule,
+    RouterLink,
+    MatButtonModule,
+    MatIconModule,
+    MatCardModule,
+    MatProgressBarModule,
+    MatChipsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatOptionModule,
+    MatDividerModule,
+    MatInputModule,
+    MatSnackBarModule,
+  ],
+})
+export class HomePageComponent {
+  private readonly boardState = inject(BoardState);
+  private readonly commentsState = inject(StoryCommentsState);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+
+  protected readonly summary = this.boardState.summary;
+  protected readonly storyOptions = computed(() =>
+    this.boardState
+      .stories()
+      .map((story) => ({ id: story.id, title: story.title, assignee: story.assignee })),
+  );
+
+  protected readonly recentComments = computed<readonly RecentComment[]>(() =>
+    this.boardState
+      .stories()
+      .flatMap((story) =>
+        story.comments.map(
+          (comment) =>
+            ({
+              storyId: story.id,
+              storyTitle: story.title,
+              comment,
+            }) satisfies RecentComment,
+        ),
+      )
+      .sort((a, b) => Date.parse(b.comment.createdAtIso) - Date.parse(a.comment.createdAtIso))
+      .slice(0, 4),
+  );
+
+  protected readonly quickCommentForm = this.formBuilder.group({
+    storyId: this.formBuilder.control('', Validators.required),
+    author: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+    message: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
+  });
+
+  private readonly hydrateFormDefaults = effect(
+    () => {
+      const stories = this.boardState.stories();
+      if (stories.length === 0) {
+        return;
+      }
+
+      const currentStoryId = this.quickCommentForm.controls.storyId.value;
+      if (!currentStoryId || !stories.some((story) => story.id === currentStoryId)) {
+        this.quickCommentForm.controls.storyId.setValue(stories[0]?.id ?? '');
+      }
+
+      const currentAuthor = this.quickCommentForm.controls.author.value;
+      if (currentAuthor.length === 0) {
+        const defaultAssignee = stories.find((story) => story.id === this.quickCommentForm.controls.storyId.value)?.assignee;
+        if (defaultAssignee) {
+          this.quickCommentForm.controls.author.setValue(defaultAssignee);
+        }
+      }
+    },
+    { allowSignalWrites: true },
+  );
+
+  protected trackRecentComment(_: number, entry: RecentComment): string {
+    return entry.comment.id;
+  }
+
+  protected onSubmitQuickComment(): void {
+    if (this.quickCommentForm.invalid) {
+      this.quickCommentForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.quickCommentForm.getRawValue();
+    const created = this.commentsState.addComment(value.storyId, {
+      author: value.author,
+      message: value.message,
+    });
+
+    if (!created) {
+      this.snackBar.open('Não foi possível registrar o comentário. Confira os campos e tente novamente.', 'Fechar', {
+        duration: 4000,
+      });
+      return;
+    }
+
+    this.quickCommentForm.controls.message.setValue('');
+    this.quickCommentForm.controls.message.markAsPristine();
+    this.quickCommentForm.controls.message.markAsUntouched();
+
+    const storyTitle = this.storyOptions().find((option) => option.id === value.storyId)?.title ?? 'história selecionada';
+    if (created.mentions.length > 0) {
+      this.snackBar.open(
+        `Menção enviada para ${created.mentions.join(', ')} em ${storyTitle}.`,
+        'Ok',
+        { duration: 5000 },
+      );
+    } else {
+      this.snackBar.open(`Comentário publicado em ${storyTitle}.`, 'Ok', {
+        duration: 3500,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated home feature that surfaces mission highlights and recent discussions
- streamline the board page to focus on task columns and sprint filtering
- update navigation and routing so the overview lives at `/` and the board moves to `/quadro`

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fce84ea48333b33ebd5eb2ac2507