### PR TITLE
feat: allow customizing board status icon color

### DIFF
--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.html
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.html
@@ -6,10 +6,18 @@
     aria-modal="true"
     [attr.aria-labelledby]="'status-editor-title-' + status().id"
   >
-    <form class="status-editor-modal__form" [formGroup]="form" (ngSubmit)="onSubmit()" novalidate>
+    <form
+      class="status-editor-modal__form"
+      [formGroup]="form"
+      (ngSubmit)="onSubmit()"
+      [style.--status-icon-color]="iconColorPreview()"
+      novalidate
+    >
       <header class="status-editor-modal__header">
         <div class="status-editor-modal__symbol" aria-hidden="true">
-          <span class="material-symbols-rounded">{{ status().icon }}</span>
+          <span class="material-symbols-rounded">
+            {{ form.controls.icon.value || status().icon }}
+          </span>
         </div>
         <div>
           <h2 [id]="'status-editor-title-' + status().id">Editar etapa</h2>
@@ -55,6 +63,17 @@
               </option>
             </select>
           </div>
+        </label>
+
+        <label class="status-editor-modal__field status-editor-modal__field--color">
+          <span>Cor do ícone</span>
+          <div class="status-editor-modal__color-picker">
+            <input type="color" formControlName="color" aria-label="Selecionar cor do ícone" />
+            <span class="status-editor-modal__color-value">{{ iconColorPreview() }}</span>
+          </div>
+          <small *ngIf="form.controls.color.invalid && form.controls.color.touched">
+            Use um valor hexadecimal válido, como #7c5cff.
+          </small>
         </label>
       </div>
 

--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.scss
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.scss
@@ -47,11 +47,12 @@
   width: 3rem;
   height: 3rem;
   border-radius: 1rem;
-  background: rgba(var(--hk-accent-rgb), 0.25);
+  background: color-mix(in srgb, var(--status-icon-color, #7c5cff) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--status-icon-color, #7c5cff) 45%, transparent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: #ede9fe;
+  color: color-mix(in srgb, var(--status-icon-color, #ede9fe) 90%, white 10%);
   font-size: 1.9rem;
 }
 
@@ -142,9 +143,54 @@
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 0.8rem;
-  background: rgba(var(--hk-accent-rgb), 0.2);
-  color: #f8fafc;
+  background: color-mix(in srgb, var(--status-icon-color, #7c5cff) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--status-icon-color, #7c5cff) 35%, transparent);
+  color: var(--status-icon-color, #f8fafc);
   font-size: 1.7rem;
+}
+
+.status-editor-modal__field--color {
+  gap: 0.65rem;
+}
+
+.status-editor-modal__color-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.status-editor-modal__color-picker input[type='color'] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border: none;
+  border-radius: 0.9rem;
+  background: none;
+  cursor: pointer;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.status-editor-modal__color-picker input[type='color']::-webkit-color-swatch-wrapper {
+  padding: 0;
+  border-radius: inherit;
+}
+
+.status-editor-modal__color-picker input[type='color']::-webkit-color-swatch {
+  border: none;
+  border-radius: inherit;
+}
+
+.status-editor-modal__color-picker input[type='color']::-moz-color-swatch {
+  border: none;
+  border-radius: inherit;
+}
+
+.status-editor-modal__color-value {
+  font-family: 'Chakra Petch', 'Inter', 'Segoe UI', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.05em;
 }
 
 .status-editor-modal__footer {

--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.ts
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.ts
@@ -24,6 +24,7 @@ export type StatusEditorFormValue = Readonly<{
   name: string;
   description: string;
   icon: string;
+  color: string;
 }>;
 
 @Component({
@@ -47,6 +48,18 @@ export class StatusEditorModalComponent {
     name: this.formBuilder.control('', [Validators.required, Validators.minLength(3)]),
     description: this.formBuilder.control(''),
     icon: this.formBuilder.control('', Validators.required),
+    color: this.formBuilder.control('', [Validators.required, Validators.pattern(/^#([0-9a-f]{6})$/i)]),
+  });
+
+  protected readonly iconColorPreview = computed(() => {
+    const control = this.form.controls.color;
+    const value = control.value?.trim();
+
+    if (value && /^#([0-9a-f]{6})$/i.test(value)) {
+      return value.toLowerCase();
+    }
+
+    return this.status().color;
   });
 
   protected readonly iconOptionsWithFallback = computed(() => {
@@ -67,6 +80,7 @@ export class StatusEditorModalComponent {
         name: current.name,
         description: current.description,
         icon: current.icon,
+        color: current.color,
       });
     },
     { allowSignalWrites: true },
@@ -87,6 +101,7 @@ export class StatusEditorModalComponent {
       name: value.name.trim(),
       description: value.description?.trim() ?? '',
       icon: value.icon.trim(),
+      color: value.color.trim().toLowerCase(),
     };
 
     this.submitted.emit(payload);

--- a/src/app/features/board-customizer/pages/board-customizer.page.html
+++ b/src/app/features/board-customizer/pages/board-customizer.page.html
@@ -24,6 +24,7 @@
         cdkDrag
         cdkDragLockAxis="y"
         [cdkDragData]="status"
+        [style.--status-icon-color]="status.color"
       >
         <div class="status-item__main">
           <span class="material-symbols-rounded status-item__icon" aria-hidden="true">{{ status.icon }}</span>

--- a/src/app/features/board-customizer/pages/board-customizer.page.scss
+++ b/src/app/features/board-customizer/pages/board-customizer.page.scss
@@ -100,8 +100,9 @@
   width: 3rem;
   height: 3rem;
   border-radius: 1rem;
-  background: color-mix(in srgb, var(--hk-accent-soft) 70%, var(--hk-surface));
-  color: var(--hk-text-primary);
+  background: color-mix(in srgb, var(--status-icon-color, var(--hk-accent)) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--status-icon-color, var(--hk-accent)) 35%, transparent);
+  color: var(--status-icon-color, var(--hk-text-primary));
   font-size: 1.8rem;
 }
 

--- a/src/app/features/board-customizer/pages/board-customizer.page.ts
+++ b/src/app/features/board-customizer/pages/board-customizer.page.ts
@@ -142,6 +142,11 @@ export class BoardCustomizerPageComponent {
       this.boardConfig.updateStatusIcon(current.id, normalizedIcon);
     }
 
+    const normalizedColor = update.color.trim().toLowerCase();
+    if (normalizedColor !== current.color) {
+      this.boardConfig.updateStatusColor(current.id, normalizedColor);
+    }
+
     this.closeStatusEditor();
   }
 

--- a/src/app/features/board/state/board-config.state.ts
+++ b/src/app/features/board/state/board-config.state.ts
@@ -6,6 +6,7 @@ type BoardStatusEditorOption = Readonly<{
   name: string;
   description: string;
   icon: string;
+  color: string;
   isActive: boolean;
   order: number;
 }>;
@@ -25,7 +26,7 @@ export class BoardConfigState {
       shortLabel: 'Backlog',
       description: 'Ideias priorizadas aguardando missão de kickoff.',
       category: 'todo',
-      color: 'var(--hk-status-backlog)',
+      color: '#7c5cff',
       icon: 'lightbulb',
       order: 1,
       wipLimit: 12,
@@ -38,7 +39,7 @@ export class BoardConfigState {
       shortLabel: 'Ready',
       description: 'Briefing validado, squad alinhado e artefatos prontos.',
       category: 'todo',
-      color: 'var(--hk-status-ready)',
+      color: '#4f46e5',
       icon: 'rocket_launch',
       order: 2,
       wipLimit: 6,
@@ -51,7 +52,7 @@ export class BoardConfigState {
       shortLabel: 'Dev',
       description: 'Squad em missão ativa, acompanhando XP diário.',
       category: 'in_progress',
-      color: 'var(--hk-status-in-dev)',
+      color: '#f59e0b',
       icon: 'smart_toy',
       order: 3,
       wipLimit: 4,
@@ -64,7 +65,7 @@ export class BoardConfigState {
       shortLabel: 'Review',
       description: 'QA funcional, feedback dos jogadores e ajuste fino.',
       category: 'in_progress',
-      color: 'var(--hk-status-code-review)',
+      color: '#f97316',
       icon: 'stadia_controller',
       order: 4,
       wipLimit: 3,
@@ -77,7 +78,7 @@ export class BoardConfigState {
       shortLabel: 'Deploy',
       description: 'Feature pronta para o lançamento global.',
       category: 'in_progress',
-      color: 'var(--hk-status-release)',
+      color: '#38bdf8',
       icon: 'rocket',
       order: 5,
       wipLimit: 2,
@@ -90,7 +91,7 @@ export class BoardConfigState {
       shortLabel: 'Done',
       description: 'Missões que renderam XP para a guilda.',
       category: 'done',
-      color: 'var(--hk-status-done)',
+      color: '#22c55e',
       icon: 'emoji_events',
       order: 6,
       isActive: true,
@@ -102,7 +103,7 @@ export class BoardConfigState {
       shortLabel: 'Ice',
       description: 'Ideias estacionadas aguardando novo contexto.',
       category: 'todo',
-      color: 'var(--hk-status-icebox)',
+      color: '#94a3b8',
       icon: 'ac_unit',
       order: 0,
       isActive: false,
@@ -114,7 +115,7 @@ export class BoardConfigState {
       shortLabel: 'Block',
       description: 'Dependências ou riscos críticos identificados.',
       category: 'in_progress',
-      color: 'var(--hk-status-blocked)',
+      color: '#f87171',
       icon: 'report',
       order: 7,
       wipLimit: 2,
@@ -138,6 +139,7 @@ export class BoardConfigState {
         name: status.name,
         description: status.description,
         icon: status.icon,
+        color: status.color,
         isActive: status.isActive,
         order: status.order,
       })),
@@ -228,7 +230,7 @@ export class BoardConfigState {
               ? normalizedDescription
               : `Missões na etapa ${name.toLowerCase()}.`,
           category: 'in_progress',
-          color: '#0ea5e9',
+          color: '#38bdf8',
           icon,
           order: nextOrder,
           isActive: true,
@@ -294,6 +296,26 @@ export class BoardConfigState {
           ? {
               ...status,
               icon: nextIcon,
+            }
+          : status,
+      ),
+    );
+  }
+
+  updateStatusColor(statusId: string, color: string): void {
+    const normalized = color.trim().toLowerCase();
+    const isHexColor = /^#([0-9a-f]{6})$/i.test(normalized);
+
+    if (!isHexColor) {
+      return;
+    }
+
+    this._statuses.update((statuses) =>
+      statuses.map((status) =>
+        status.id === statusId
+          ? {
+              ...status,
+              color: normalized,
             }
           : status,
       ),

--- a/src/app/features/board/state/board-state.service.ts
+++ b/src/app/features/board/state/board-state.service.ts
@@ -650,7 +650,7 @@ export class BoardState {
           title: story.title,
           estimateLabel: `${story.estimate} pts`,
           statusLabel: status?.name ?? 'Etapa desconhecida',
-          statusColor: status?.color ?? 'var(--hk-status-icebox)',
+          statusColor: status?.color ?? '#94a3b8',
           tasks: story.tasks.map((task) => ({
             id: task.id,
             title: task.title,
@@ -987,7 +987,7 @@ export class BoardState {
       featureMission: feature?.mission ?? 'Missão a ser definida com o squad.',
       statusLabel: status?.name ?? 'Etapa desconhecida',
       statusDescription: status?.description ?? 'Etapa não mapeada no fluxo do quadro.',
-      statusColor: status?.color ?? 'var(--hk-status-icebox)',
+      statusColor: status?.color ?? '#94a3b8',
       statusIcon: status?.icon ?? 'help',
       priorityLabel: this.mapPriorityLabel(story.priority),
       priorityColor: PRIORITY_COLORS[story.priority],

--- a/src/app/features/feature-explorer/state/feature-explorer.state.ts
+++ b/src/app/features/feature-explorer/state/feature-explorer.state.ts
@@ -44,7 +44,7 @@ export class FeatureExplorerState {
     for (const story of stories) {
       const status = statusById.get(story.statusId);
       const statusLabel = status?.name ?? 'Status desconhecido';
-      const statusColor = status?.color ?? 'var(--hk-status-icebox)';
+      const statusColor = status?.color ?? '#94a3b8';
       const storyCard = this.toStoryCard(story, statusLabel, statusColor);
       const existing = storyCardsByFeature.get(story.featureId) ?? [];
       storyCardsByFeature.set(story.featureId, [...existing, storyCard]);


### PR DESCRIPTION
## Summary
- add a color picker to the status editor so the icon preview uses the selected tint
- persist status colors as hexadecimal values and surface them across the customizer UI
- update board and feature explorer view models to rely on the stored color instead of theme variables

## Testing
- `npm run lint` *(fails: Missing script "lint" in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e303a7100483338ec591092f97e989