### PR TITLE
fix: restrict color picker activation to swatch

### DIFF
--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.html
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.html
@@ -65,16 +65,22 @@
           </div>
         </label>
 
-        <label class="status-editor-modal__field status-editor-modal__field--color">
-          <span>Cor do ícone</span>
+        <div class="status-editor-modal__field status-editor-modal__field--color">
+          <span [id]="colorLabelId()">Cor do ícone</span>
           <div class="status-editor-modal__color-picker">
-            <input type="color" formControlName="color" aria-label="Selecionar cor do ícone" />
+            <input
+              type="color"
+              [id]="colorInputId()"
+              formControlName="color"
+              [attr.aria-labelledby]="colorLabelId()"
+              aria-label="Selecionar cor do ícone"
+            />
             <span class="status-editor-modal__color-value">{{ iconColorPreview() }}</span>
           </div>
           <small *ngIf="form.controls.color.invalid && form.controls.color.touched">
             Use um valor hexadecimal válido, como #7c5cff.
           </small>
-        </label>
+        </div>
       </div>
 
       <footer class="status-editor-modal__footer">

--- a/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.ts
+++ b/src/app/features/board-customizer/components/status-editor-modal/status-editor-modal.component.ts
@@ -73,6 +73,9 @@ export class StatusEditorModalComponent {
     return [...options, { value: currentIcon, label: currentIcon } satisfies IconOption];
   });
 
+  protected readonly colorInputId = computed(() => `status-color-${this.status().id}`);
+  protected readonly colorLabelId = computed(() => `status-color-label-${this.status().id}`);
+
   private readonly syncFormEffect = effect(
     () => {
       const current = this.status();


### PR DESCRIPTION
## Summary
- stop triggering the status color picker when clicking anywhere on the field label
- generate deterministic ids to associate the color swatch with its label via aria-labelledby

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e307a8a68c8333bf2453efaaa8121e