### PR TITLE
Sync accent styling tokens with the selected theme

### DIFF
--- a/src/app/core/state/theme.state.spec.ts
+++ b/src/app/core/state/theme.state.spec.ts
@@ -107,6 +107,30 @@ describe('ThemeState', () => {
     expect(overlayContainerElement.dataset['theme']).toBe('radiant-dawn');
   });
 
+  it('should update accent tokens so UI components follow the active theme', () => {
+    state.setAvailableThemes(createThemeFixtures());
+    state.setTheme('radiant-dawn');
+
+    const rootStyle = documentRef.documentElement.style;
+    const bodyStyle = documentRef.body.style;
+    const overlayStyle = overlayContainerElement.style;
+
+    expect(rootStyle.getPropertyValue('--hk-accent').trim()).toBe('#f97316');
+    expect(rootStyle.getPropertyValue('--hk-accent-soft').trim()).toBe('rgba(249, 115, 22, 0.24)');
+    expect(rootStyle.getPropertyValue('--hk-accent-rgb').trim()).toBe('249, 115, 22');
+    expect(rootStyle.getPropertyValue('--hk-accent-strong').trim()).toBe('#f97316');
+    expect(rootStyle.getPropertyValue('--hk-accent-strong-rgb').trim()).toBe('249, 115, 22');
+    expect(rootStyle.getPropertyValue('--hk-accent-gradient').trim()).toBe(
+      'linear-gradient(135deg, #fff7ed 0%, #fed7aa 100%)',
+    );
+    expect(rootStyle.getPropertyValue('--hk-accent-gradient-progress').trim()).toBe(
+      'linear-gradient(135deg, #fff7ed 0%, #fed7aa 100%)',
+    );
+
+    expect(bodyStyle.getPropertyValue('--hk-accent').trim()).toBe('#f97316');
+    expect(overlayStyle.getPropertyValue('--hk-accent').trim()).toBe('#f97316');
+  });
+
   it('should apply the Celestial Tides theme tokens when selected', () => {
     state.setAvailableThemes(createThemeFixtures());
     state.setTheme('celestial-tides');

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -144,17 +144,20 @@ export class ThemeState {
 
     if (rootElement) {
       rootElement.dataset['theme'] = themeId;
+      this.applyAccentTokens(rootElement, theme);
       this.applyProfileTokens(rootElement, profileTokens);
       this.applyFontFamily(rootElement, previewFontFamily);
     }
 
     if (bodyElement) {
       bodyElement.dataset['theme'] = themeId;
+      this.applyAccentTokens(bodyElement, theme);
       this.applyFontFamily(bodyElement, previewFontFamily);
     }
 
     if (overlayElement) {
       overlayElement.dataset['theme'] = themeId;
+      this.applyAccentTokens(overlayElement, theme);
       this.applyFontFamily(overlayElement, previewFontFamily);
     }
   }
@@ -214,6 +217,92 @@ export class ThemeState {
     }
 
     styleElement.textContent = stylesheet;
+  }
+
+  private applyAccentTokens(target: HTMLElement, theme: ThemeOption | undefined): void {
+    if (!target) {
+      return;
+    }
+
+    if (!theme) {
+      this.clearAccentTokens(target);
+      return;
+    }
+
+    const accent = theme.accent?.trim();
+    const softAccent = theme.softAccent?.trim();
+    const previewGradient = theme.previewGradient?.trim();
+
+    this.setCssVariable(target, '--hk-accent', accent);
+    this.setCssVariable(target, '--hk-accent-soft', softAccent);
+    this.setCssVariable(target, '--hk-accent-gradient', previewGradient);
+    this.setCssVariable(target, '--hk-accent-gradient-progress', previewGradient);
+
+    if (accent) {
+      const accentRgb = this.toRgbValue(accent);
+
+      if (accentRgb) {
+        target.style.setProperty('--hk-accent-rgb', accentRgb);
+        target.style.setProperty('--hk-accent-strong', accent);
+        target.style.setProperty('--hk-accent-strong-rgb', accentRgb);
+      } else {
+        target.style.removeProperty('--hk-accent-rgb');
+        target.style.removeProperty('--hk-accent-strong');
+        target.style.removeProperty('--hk-accent-strong-rgb');
+      }
+    } else {
+      target.style.removeProperty('--hk-accent-rgb');
+      target.style.removeProperty('--hk-accent-strong');
+      target.style.removeProperty('--hk-accent-strong-rgb');
+    }
+  }
+
+  private clearAccentTokens(target: HTMLElement): void {
+    target.style.removeProperty('--hk-accent');
+    target.style.removeProperty('--hk-accent-soft');
+    target.style.removeProperty('--hk-accent-rgb');
+    target.style.removeProperty('--hk-accent-strong');
+    target.style.removeProperty('--hk-accent-strong-rgb');
+    target.style.removeProperty('--hk-accent-gradient');
+    target.style.removeProperty('--hk-accent-gradient-progress');
+  }
+
+  private setCssVariable(target: HTMLElement, variableName: string, value: string | undefined): void {
+    if (!value) {
+      target.style.removeProperty(variableName);
+      return;
+    }
+
+    const normalizedValue = value.trim();
+
+    if (normalizedValue.length === 0) {
+      target.style.removeProperty(variableName);
+      return;
+    }
+
+    target.style.setProperty(variableName, normalizedValue);
+  }
+
+  private toRgbValue(color: string): string | null {
+    const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim());
+
+    if (!hexMatch) {
+      return null;
+    }
+
+    const hex = hexMatch[1];
+
+    const normalizedHex = hex.length === 3 ? hex.split('').map((char) => char + char).join('') : hex;
+
+    const red = parseInt(normalizedHex.substring(0, 2), 16);
+    const green = parseInt(normalizedHex.substring(2, 4), 16);
+    const blue = parseInt(normalizedHex.substring(4, 6), 16);
+
+    if (Number.isNaN(red) || Number.isNaN(green) || Number.isNaN(blue)) {
+      return null;
+    }
+
+    return `${red}, ${green}, ${blue}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- propagate accent-related CSS variables from the active theme to the document, body, and overlay containers so UI buttons follow theme colors
- add unit coverage ensuring accent tokens update when a new theme is selected

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e30b7fa6788333b8687fd9147143b4