### PR TITLE
feat: theme home page quick actions

### DIFF
--- a/src/app/features/home/pages/home.page.html
+++ b/src/app/features/home/pages/home.page.html
@@ -14,8 +14,8 @@
       <mat-card-content>
         <div class="home__summary-grid">
           <div class="home__actions" role="group" aria-label="Ações rápidas do quadro">
-            <a mat-flat-button color="primary" routerLink="/quadro">
-              <mat-icon fontSet="material-symbols-rounded">add_circle</mat-icon>
+            <a mat-flat-button color="primary" class="home__accent-button" routerLink="/quadro">
+              <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">add_circle</mat-icon>
               Nova história
             </a>
           </div>
@@ -135,7 +135,7 @@
           </mat-form-field>
 
           <div class="home__conversation-actions">
-            <button type="submit" mat-flat-button color="primary">
+            <button type="submit" mat-flat-button color="primary" class="home__accent-button">
               <mat-icon fontSet="material-symbols-rounded" aria-hidden="true">send</mat-icon>
               Publicar atualização
             </button>

--- a/src/app/features/home/pages/home.page.scss
+++ b/src/app/features/home/pages/home.page.scss
@@ -76,7 +76,13 @@
   }
 }
 
-.home__actions :is(a[mat-flat-button], a[mat-stroked-button], button[mat-flat-button], button[mat-stroked-button]) {
+
+.home__accent-button {
+  --mdc-filled-button-container-color: transparent;
+  --mdc-filled-button-hover-state-layer-color: transparent;
+  --mdc-filled-button-focus-state-layer-color: transparent;
+  --mdc-filled-button-pressed-state-layer-color: transparent;
+  --mdc-filled-button-label-text-color: var(--hk-text-primary);
   min-height: 3rem;
   padding-inline: 1.25rem;
   font-weight: 600;
@@ -84,6 +90,41 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  background: var(--hk-accent-gradient);
+  color: var(--hk-text-primary);
+  border: 1px solid rgba(var(--hk-accent-strong-rgb), 0.45);
+  box-shadow: 0 14px 32px rgba(var(--hk-accent-strong-rgb), 0.35);
+  transition: transform 150ms ease, box-shadow 150ms ease, filter 150ms ease;
+  will-change: transform;
+
+  &:hover {
+    box-shadow: 0 18px 42px rgba(var(--hk-accent-strong-rgb), 0.45);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: 0 12px 28px rgba(var(--hk-accent-strong-rgb), 0.4);
+    filter: brightness(0.95);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--hk-accent-strong);
+    outline-offset: 3px;
+  }
+
+  &[disabled] {
+    background: rgba(var(--hk-accent-strong-rgb), 0.25);
+    border-color: rgba(var(--hk-accent-strong-rgb), 0.25);
+    box-shadow: none;
+    color: var(--hk-text-muted);
+    filter: none;
+    transform: none;
+  }
+}
+
+.home__accent-button mat-icon {
+  color: currentColor;
 }
 
 .home__progress {


### PR DESCRIPTION
## Summary
- style the home page quick action buttons to follow the accent gradient used on the board
- update the publish update action to share the themed treatment and keep icons accessible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30e72bc8c833389a36374a89093cb