### PR TITLE
feat: refresh hero profile layout with modal sections

### DIFF
--- a/src/app/features/profile/components/profile-achievements-dialog/profile-achievements-dialog.component.html
+++ b/src/app/features/profile/components/profile-achievements-dialog/profile-achievements-dialog.component.html
@@ -1,0 +1,29 @@
+<header class="dialog__header">
+  <div>
+    <h2>Conquistas da guilda</h2>
+    <p>Reviva feitos memoráveis, acompanhe o progresso coletivo e planeje o próximo título lendário.</p>
+  </div>
+  <button type="button" mat-icon-button (click)="close()" aria-label="Fechar conquistas">
+    <span class="material-symbols-rounded" aria-hidden="true">close</span>
+  </button>
+</header>
+
+<p class="dialog__xp">Total de XP atual: {{ experience().current | number: '1.0-0' }} · Próximo nível aos {{ experience().nextLevel | number: '1.0-0' }}.</p>
+
+<ul class="achievement-list">
+  <li *ngFor="let achievement of achievements(); trackBy: trackAchievement">
+    <article class="achievement-card" [attr.aria-label]="'Conquista ' + achievement.title">
+      <header>
+        <span class="achievement-card__icon" aria-hidden="true">★</span>
+        <div>
+          <p class="achievement-card__title">{{ achievement.title }}</p>
+          <p class="achievement-card__description">{{ achievement.description }}</p>
+        </div>
+      </header>
+      <div class="achievement-card__progress" role="img" [attr.aria-label]="experienceProgressLabel(achievement)">
+        <div class="achievement-card__progress-bar" [style.width.%]="achievement.progress"></div>
+      </div>
+      <span class="achievement-card__value">{{ achievement.progress }}%</span>
+    </article>
+  </li>
+</ul>

--- a/src/app/features/profile/components/profile-achievements-dialog/profile-achievements-dialog.component.scss
+++ b/src/app/features/profile/components/profile-achievements-dialog/profile-achievements-dialog.component.scss
@@ -1,0 +1,99 @@
+:host {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  color: var(--hk-text-primary);
+}
+
+.dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.dialog__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.dialog__header p {
+  margin: 0.35rem 0 0;
+  color: var(--hk-text-muted);
+}
+
+.dialog__header button[mat-icon-button] {
+  --mdc-icon-button-icon-color: var(--hk-text-secondary);
+}
+
+.dialog__xp {
+  margin: 0;
+  color: var(--hk-text-secondary);
+}
+
+.achievement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.achievement-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.achievement-card > header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.achievement-card__icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.9rem;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, #facc15, #f97316);
+  color: #16121f;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.achievement-card__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.achievement-card__description {
+  margin: 0.25rem 0 0;
+  color: var(--hk-text-muted);
+  font-size: 0.95rem;
+}
+
+.achievement-card__progress {
+  position: relative;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.16);
+  overflow: hidden;
+}
+
+.achievement-card__progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--hk-accent-gradient);
+}
+
+.achievement-card__value {
+  justify-self: end;
+  font-size: 0.9rem;
+  color: var(--hk-text-muted);
+}

--- a/src/app/features/profile/components/profile-achievements-dialog/profile-achievements-dialog.component.ts
+++ b/src/app/features/profile/components/profile-achievements-dialog/profile-achievements-dialog.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { NgFor, DecimalPipe } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { HeroControlState } from '@app/core/state/hero-control.state';
+import type { ProfileAchievement } from '@app/core/state/hero-control.models';
+
+@Component({
+  selector: 'hk-profile-achievements-dialog',
+  standalone: true,
+  templateUrl: './profile-achievements-dialog.component.html',
+  styleUrls: ['./profile-achievements-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatDialogModule, MatButtonModule, NgFor, DecimalPipe],
+})
+export class ProfileAchievementsDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<ProfileAchievementsDialogComponent>);
+  private readonly heroControl = inject(HeroControlState);
+
+  protected readonly achievements = this.heroControl.achievements;
+  protected readonly experience = this.heroControl.experience;
+  protected readonly trackAchievement = this.heroControl.trackAchievement.bind(this.heroControl);
+
+  protected close(): void {
+    this.dialogRef.close();
+  }
+
+  protected experienceProgressLabel(achievement: ProfileAchievement): string {
+    return `Progresso da conquista ${achievement.title} em ${achievement.progress}%`;
+  }
+}

--- a/src/app/features/profile/components/profile-loot-dialog/profile-loot-dialog.component.html
+++ b/src/app/features/profile/components/profile-loot-dialog/profile-loot-dialog.component.html
@@ -1,0 +1,36 @@
+<header class="dialog__header">
+  <div>
+    <h2>Inventário mágico</h2>
+    <p>Organize artefatos raros, monitore quantidades e distribua recursos entre as squads.</p>
+  </div>
+  <button type="button" mat-icon-button (click)="close()" aria-label="Fechar inventário">
+    <span class="material-symbols-rounded" aria-hidden="true">close</span>
+  </button>
+</header>
+
+<p class="dialog__summary">Total de itens na bolsa: {{ totalQuantity() }} peças.</p>
+
+<ul class="loot-list">
+  <li *ngFor="let item of loot(); trackBy: trackLoot" [attr.data-rarity]="item.rarity">
+    <div class="loot-card">
+      <div class="loot-card__header">
+        <span class="loot-card__icon material-symbols-rounded" aria-hidden="true">auto_awesome</span>
+        <div>
+          <p class="loot-card__name">{{ item.name }}</p>
+          <p class="loot-card__rarity">Raridade {{ item.rarity }}</p>
+        </div>
+      </div>
+      <span class="loot-card__quantity">×{{ item.quantity }}</span>
+    </div>
+  </li>
+</ul>
+
+<section class="loot-groups" aria-label="Grupos por raridade">
+  <h3>Resumo por raridade</h3>
+  <ul>
+    <li *ngFor="let group of rarityGroups()">
+      <span class="loot-groups__rarity">{{ group[0] }}</span>
+      <span class="loot-groups__count">{{ group[1].length }} itens</span>
+    </li>
+  </ul>
+</section>

--- a/src/app/features/profile/components/profile-loot-dialog/profile-loot-dialog.component.scss
+++ b/src/app/features/profile/components/profile-loot-dialog/profile-loot-dialog.component.scss
@@ -1,0 +1,129 @@
+:host {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  color: var(--hk-text-primary);
+}
+
+.dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.dialog__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.dialog__header p {
+  margin: 0.35rem 0 0;
+  color: var(--hk-text-muted);
+}
+
+.dialog__header button[mat-icon-button] {
+  --mdc-icon-button-icon-color: var(--hk-text-secondary);
+}
+
+.dialog__summary {
+  margin: 0;
+  color: var(--hk-text-secondary);
+}
+
+.loot-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.loot-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.loot-card__header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.loot-card__icon {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.85rem;
+  background: radial-gradient(circle at top, rgba(168, 85, 247, 0.9), rgba(59, 130, 246, 0.75));
+  color: #0a0d1c;
+}
+
+.loot-card__name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.loot-card__rarity {
+  margin: 0.15rem 0 0;
+  color: var(--hk-text-muted);
+  font-size: 0.9rem;
+}
+
+.loot-card__quantity {
+  font-weight: 600;
+}
+
+.loot-list li[data-rarity='raro'] .loot-card {
+  border-color: rgba(56, 189, 248, 0.5);
+}
+
+.loot-list li[data-rarity='lendário'] .loot-card {
+  border-color: rgba(250, 204, 21, 0.6);
+  box-shadow: 0 0 14px rgba(250, 204, 21, 0.24);
+}
+
+.loot-groups {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.loot-groups h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.loot-groups ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.loot-groups li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.loot-groups__rarity {
+  font-weight: 600;
+}
+
+.loot-groups__count {
+  color: var(--hk-text-muted);
+}

--- a/src/app/features/profile/components/profile-loot-dialog/profile-loot-dialog.component.ts
+++ b/src/app/features/profile/components/profile-loot-dialog/profile-loot-dialog.component.ts
@@ -1,0 +1,48 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { NgFor } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { HeroControlState } from '@app/core/state/hero-control.state';
+import type { LootItem } from '@app/core/state/hero-control.models';
+
+@Component({
+  selector: 'hk-profile-loot-dialog',
+  standalone: true,
+  templateUrl: './profile-loot-dialog.component.html',
+  styleUrls: ['./profile-loot-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatDialogModule, MatButtonModule, NgFor],
+})
+export class ProfileLootDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<ProfileLootDialogComponent>);
+  private readonly heroControl = inject(HeroControlState);
+
+  protected readonly loot = this.heroControl.loot;
+  protected readonly trackLoot = this.heroControl.trackLoot.bind(this.heroControl);
+  protected readonly totalQuantity = computed(() =>
+    this.loot().reduce((total, item) => total + item.quantity, 0),
+  );
+
+  protected readonly rarityGroups = computed(() => {
+    const groups = new Map<LootItem['rarity'], LootItem[]>();
+    const rarityOrder: Record<LootItem['rarity'], number> = {
+      lendário: 3,
+      raro: 2,
+      comum: 1,
+    } as const;
+
+    for (const item of this.loot()) {
+      const items = groups.get(item.rarity) ?? [];
+      items.push(item);
+      groups.set(item.rarity, items);
+    }
+
+    return Array.from(groups.entries()).sort(
+      ([rarityA], [rarityB]) => rarityOrder[rarityB] - rarityOrder[rarityA],
+    );
+  });
+
+  protected close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/features/profile/components/profile-themes-dialog/profile-themes-dialog.component.html
+++ b/src/app/features/profile/components/profile-themes-dialog/profile-themes-dialog.component.html
@@ -1,0 +1,39 @@
+<header class="dialog__header">
+  <div>
+    <h2>Temas & ambientação</h2>
+    <p>Escolha o clima visual que melhor representa o espírito aventureiro da guilda.</p>
+  </div>
+  <button type="button" mat-icon-button (click)="close()" aria-label="Fechar seleção de temas">
+    <span class="material-symbols-rounded" aria-hidden="true">close</span>
+  </button>
+</header>
+
+<ul class="theme-options" role="radiogroup" aria-label="Temas disponíveis">
+  <li *ngFor="let theme of themes(); trackBy: trackTheme" class="theme-options__item">
+    <input
+      type="radio"
+      class="theme-option__input"
+      name="theme-selection"
+      [id]="'dialog-theme-' + theme.id"
+      [value]="theme.id"
+      [checked]="isThemeSelected(theme.id)"
+      (change)="onThemeSelect(theme.id)"
+    />
+    <label
+      class="theme-option__card"
+      [attr.for]="'dialog-theme-' + theme.id"
+      [class.theme-option__card--active]="isThemeSelected(theme.id)"
+      [style.--theme-accent]="theme.accent"
+      [style.--theme-soft-accent]="theme.softAccent"
+      [style.--theme-preview]="theme.previewGradient"
+      [style.--theme-font-family]="theme.previewFontFamily"
+    >
+      <span class="theme-option__preview" aria-hidden="true"></span>
+      <span class="theme-option__content">
+        <span class="theme-option__title">{{ theme.label }}</span>
+        <span class="theme-option__description">{{ theme.description }}</span>
+      </span>
+      <span class="theme-option__badge" *ngIf="isThemeSelected(theme.id)">Ativo</span>
+    </label>
+  </li>
+</ul>

--- a/src/app/features/profile/components/profile-themes-dialog/profile-themes-dialog.component.scss
+++ b/src/app/features/profile/components/profile-themes-dialog/profile-themes-dialog.component.scss
@@ -1,0 +1,122 @@
+:host {
+  display: grid;
+  gap: 1.75rem;
+  padding: 1.75rem;
+  color: var(--hk-text-primary);
+}
+
+.dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.dialog__header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+}
+
+.dialog__header p {
+  margin: 0.35rem 0 0;
+  color: var(--hk-text-muted);
+}
+
+.dialog__header button[mat-icon-button] {
+  --mdc-icon-button-icon-color: var(--hk-text-secondary);
+}
+
+.theme-options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.theme-options__item {
+  position: relative;
+}
+
+.theme-option__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.theme-option__card {
+  --theme-accent: var(--hk-accent);
+  --theme-soft-accent: rgba(var(--hk-accent-rgb), 0.22);
+  --theme-preview: linear-gradient(
+    135deg,
+    rgba(var(--hk-accent-rgb), 0.5),
+    rgba(var(--hk-accent-rgb), 0.1)
+  );
+  --theme-font-family: var(--hk-heading-font-family);
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 1.15rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+  cursor: pointer;
+  position: relative;
+  min-height: 100%;
+}
+
+.theme-option__card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.theme-option__card--active {
+  border-color: var(--theme-accent);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18), 0 0 0 1px var(--theme-accent);
+}
+
+.theme-option__input:focus-visible + .theme-option__card {
+  box-shadow: 0 0 0 1px var(--theme-accent), 0 0 0 4px var(--theme-soft-accent);
+}
+
+.theme-option__card--active .theme-option__title {
+  color: var(--theme-accent);
+}
+
+.theme-option__preview {
+  height: 3rem;
+  border-radius: 0.85rem;
+  background-image: var(--theme-preview);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.theme-option__content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.theme-option__title {
+  font-weight: 600;
+  font-family: var(--theme-font-family, var(--hk-heading-font-family));
+  letter-spacing: var(--hk-heading-letter-spacing, 0.03em);
+}
+
+.theme-option__description {
+  color: var(--hk-text-muted);
+  font-size: 0.95rem;
+}
+
+.theme-option__badge {
+  justify-self: start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--theme-soft-accent);
+  color: var(--theme-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}

--- a/src/app/features/profile/components/profile-themes-dialog/profile-themes-dialog.component.ts
+++ b/src/app/features/profile/components/profile-themes-dialog/profile-themes-dialog.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { NgFor, NgIf } from '@angular/common';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { ThemeState, type ThemeId, type ThemeOption } from '@app/core/state/theme.state';
+
+@Component({
+  selector: 'hk-profile-themes-dialog',
+  standalone: true,
+  templateUrl: './profile-themes-dialog.component.html',
+  styleUrls: ['./profile-themes-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatDialogModule, MatButtonModule, NgFor, NgIf],
+})
+export class ProfileThemesDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<ProfileThemesDialogComponent>);
+  private readonly themeState = inject(ThemeState);
+
+  protected readonly themes = this.themeState.themes;
+  protected readonly currentTheme = this.themeState.currentTheme;
+
+  protected trackTheme(_: number, theme: ThemeOption): ThemeId {
+    return theme.id;
+  }
+
+  protected isThemeSelected(themeId: ThemeId): boolean {
+    return this.currentTheme() === themeId;
+  }
+
+  protected onThemeSelect(themeId: ThemeId): void {
+    this.themeState.setTheme(themeId);
+  }
+
+  protected close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/features/profile/pages/profile.page.html
+++ b/src/app/features/profile/pages/profile.page.html
@@ -2,7 +2,10 @@
   <header class="profile__header">
     <div>
       <h1 id="profile-heading">Perfil do herói</h1>
-      <p>Consulte o progresso, conquistas e recompensas desbloqueadas pela guilda.</p>
+      <p>
+        Consulte a ficha de personagem, acompanhe o progresso de XP e administre os artefatos cosméticos
+        da guilda.
+      </p>
     </div>
     <span class="profile__level" aria-label="Nível atual">Lvl {{ experience().level }}</span>
   </header>
@@ -18,76 +21,145 @@
     </div>
   </section>
 
-  <section class="profile__theme" aria-labelledby="theme-heading">
+  <section class="profile__sheet" aria-labelledby="sheet-heading">
     <header>
-      <h2 id="theme-heading">Personalizar tema</h2>
-      <p>Escolha uma paleta visual para combinar com a energia da guilda.</p>
+      <h2 id="sheet-heading">Ficha de personagem</h2>
+      <p>Resumo épico das origens, classe e talentos exclusivos do herói da squad.</p>
     </header>
-    <ul class="theme-options" role="radiogroup" [attr.aria-labelledby]="'theme-heading'">
-      <li *ngFor="let theme of themes(); trackBy: trackTheme" class="theme-options__item">
-        <input
-          type="radio"
-          class="theme-option__input"
-          name="theme-selection"
-          [id]="'theme-' + theme.id"
-          [value]="theme.id"
-          [checked]="isThemeSelected(theme.id)"
-          (change)="onThemeSelect(theme.id)"
-        />
-        <label
-          class="theme-option__card"
-          [attr.for]="'theme-' + theme.id"
-          [class.theme-option__card--active]="isThemeSelected(theme.id)"
-          [style.--theme-accent]="theme.accent"
-          [style.--theme-soft-accent]="theme.softAccent"
-          [style.--theme-preview]="theme.previewGradient"
-          [style.--theme-font-family]="theme.previewFontFamily"
-        >
-          <span class="theme-option__preview" aria-hidden="true"></span>
-          <span class="theme-option__content">
-            <span class="theme-option__title">{{ theme.label }}</span>
-            <span class="theme-option__description">{{ theme.description }}</span>
-          </span>
-          <span class="theme-option__badge" *ngIf="isThemeSelected(theme.id)">Ativo</span>
-        </label>
-      </li>
-    </ul>
-  </section>
+    <div class="profile__sheet-body">
+      <dl class="profile__sheet-info">
+        <div>
+          <dt>Nome</dt>
+          <dd>{{ heroSheet.name }}</dd>
+        </div>
+        <div>
+          <dt>Título</dt>
+          <dd>{{ heroSheet.title }}</dd>
+        </div>
+        <div>
+          <dt>Classe</dt>
+          <dd>{{ heroSheet.heroClass }}</dd>
+        </div>
+        <div>
+          <dt>Guilda</dt>
+          <dd>{{ heroSheet.guild }}</dd>
+        </div>
+        <div>
+          <dt>Alinhamento</dt>
+          <dd>{{ heroSheet.alignment }}</dd>
+        </div>
+        <div>
+          <dt>Linhagem</dt>
+          <dd>{{ heroSheet.lineage }}</dd>
+        </div>
+        <div>
+          <dt>Estandarte</dt>
+          <dd>{{ heroSheet.banner }}</dd>
+        </div>
+        <div>
+          <dt>Artefato</dt>
+          <dd>{{ heroSheet.signature }}</dd>
+        </div>
+      </dl>
 
-  <section class="profile__achievements" aria-labelledby="achievements-heading">
-    <header>
-      <h2 id="achievements-heading">Conquistas desbloqueadas</h2>
-      <p>Meta conquistas colaborativas para liberar novos cosméticos e títulos.</p>
-    </header>
-    <ul>
-      <li *ngFor="let achievement of achievements(); trackBy: trackAchievement">
-        <article class="achievement-card" [attr.aria-label]="'Conquista ' + achievement.title">
-          <header>
-            <span class="achievement-card__icon" aria-hidden="true">★</span>
-            <div>
-              <p class="achievement-card__title">{{ achievement.title }}</p>
-              <p class="achievement-card__description">{{ achievement.description }}</p>
+      <div class="profile__sheet-attributes" aria-label="Atributos principais">
+        <h3>Atributos</h3>
+        <ul>
+          <li *ngFor="let attribute of heroSheet.attributes">
+            <span class="profile__attribute-label">{{ attribute.label }}</span>
+            <div class="profile__attribute-meter" role="img" [attr.aria-label]="attribute.label + ' em ' + attribute.value">
+              <div class="profile__attribute-bar" [style.width.%]="attribute.value * 5"></div>
             </div>
-          </header>
-          <div class="achievement-card__progress" role="img" [attr.aria-label]="'Progresso ' + achievement.progress + '%'">
-            <div class="achievement-card__progress-bar" [style.width.%]="achievement.progress"></div>
-          </div>
-          <span class="achievement-card__value">{{ achievement.progress }}%</span>
-        </article>
-      </li>
-    </ul>
+            <span class="profile__attribute-value">{{ attribute.value }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="profile__sheet-traits" aria-label="Traços heroicos">
+        <h3>Talentos únicos</h3>
+        <ul>
+          <li *ngFor="let trait of heroSheet.traits">
+            <strong>{{ trait.title }}</strong>
+            <p>{{ trait.description }}</p>
+          </li>
+        </ul>
+      </div>
+    </div>
   </section>
 
-  <section class="profile__loot" aria-labelledby="loot-heading">
-    <header>
-      <h2 id="loot-heading">Inventário de loots</h2>
-      <p>Itens raros conquistados em desafios recentes da guilda.</p>
-    </header>
-    <ul>
-      <li *ngFor="let item of loot(); trackBy: trackLoot" [attr.data-rarity]="item.rarity">
-        <span class="loot-card__name">{{ item.name }}</span>
-        <span class="loot-card__quantity">×{{ item.quantity }}</span>
-      </li>
-    </ul>
+  <section class="profile__cards" aria-label="Coleção de registros do perfil">
+    <article class="profile-card">
+      <button type="button" class="profile-card__trigger" (click)="openThemesDialog()" aria-describedby="themes-summary">
+        <span class="profile-card__icon material-symbols-rounded" aria-hidden="true">palette</span>
+        <div class="profile-card__content">
+          <h3>Temas & ambientação</h3>
+          <p id="themes-summary">Gerencie a paleta e fontes que moldam o quadro.</p>
+          <dl class="profile-card__stats">
+            <div>
+              <dt>Ativo</dt>
+              <dd>{{ currentThemeOption()?.label ?? 'Tema padrão' }}</dd>
+            </div>
+            <div>
+              <dt>Desbloqueados</dt>
+              <dd>{{ themesCount() }}</dd>
+            </div>
+          </dl>
+        </div>
+        <span class="profile-card__action">Abrir</span>
+      </button>
+    </article>
+
+    <article class="profile-card">
+      <button
+        type="button"
+        class="profile-card__trigger"
+        (click)="openAchievementsDialog()"
+        aria-describedby="achievements-summary"
+      >
+        <span class="profile-card__icon material-symbols-rounded" aria-hidden="true">workspace_premium</span>
+        <div class="profile-card__content">
+          <h3>Conquistas da guilda</h3>
+          <p id="achievements-summary">Relembre feitos lendários e acompanhe o próximo título.</p>
+          <dl class="profile-card__stats">
+            <div>
+              <dt>Média de progresso</dt>
+              <dd>{{ achievementsAverage() }}%</dd>
+            </div>
+            <div>
+              <dt>Destaque</dt>
+              <dd>{{ highlightedAchievement()?.title ?? 'Nenhuma missão concluída' }}</dd>
+            </div>
+          </dl>
+          <p class="profile-card__footer">
+            {{ achievements().length }} conquistas em andamento · {{ completedAchievements() }} completas
+          </p>
+        </div>
+        <span class="profile-card__action">Abrir</span>
+      </button>
+    </article>
+
+    <article class="profile-card">
+      <button type="button" class="profile-card__trigger" (click)="openLootDialog()" aria-describedby="loot-summary">
+        <span class="profile-card__icon material-symbols-rounded" aria-hidden="true">inventory_2</span>
+        <div class="profile-card__content">
+          <h3>Inventário mágico</h3>
+          <p id="loot-summary">Administre os artefatos e recursos acumulados pela party.</p>
+          <dl class="profile-card__stats">
+            <div>
+              <dt>Itens únicos</dt>
+              <dd>{{ lootUniqueCount() }}</dd>
+            </div>
+            <div>
+              <dt>Peças totais</dt>
+              <dd>{{ lootTotalQuantity() }}</dd>
+            </div>
+          </dl>
+          <p class="profile-card__footer" *ngIf="featuredLoot() as lootItem">
+            Destaque lendário: {{ lootItem.name }} · Raridade {{ lootItem.rarity }}
+          </p>
+        </div>
+        <span class="profile-card__action">Abrir</span>
+      </button>
+    </article>
   </section>
 </section>

--- a/src/app/features/profile/pages/profile.page.scss
+++ b/src/app/features/profile/pages/profile.page.scss
@@ -41,7 +41,7 @@
 .profile__header p {
   margin: 0.35rem 0 0;
   color: var(--profile-text-muted);
-  max-width: 48ch;
+  max-width: 52ch;
 }
 
 .profile__level {
@@ -59,7 +59,7 @@
   letter-spacing: 0.08em;
 }
 
-.profile__xp { 
+.profile__xp {
   display: grid;
   gap: 0.75rem;
 }
@@ -72,120 +72,6 @@
 .profile__xp p {
   margin: 0;
   color: var(--profile-text-secondary);
-}
-
-.profile__theme {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.profile__theme > header {
-  display: grid;
-  gap: 0.35rem;
-}
-
-.profile__theme > header h2 {
-  margin: 0;
-}
-
-.profile__theme > header p {
-  margin: 0;
-  color: var(--profile-text-muted);
-}
-
-.theme-options {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.theme-options__item {
-  position: relative;
-}
-
-.theme-option__input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.theme-option__card {
-  --theme-accent: var(--hk-accent);
-  --theme-soft-accent: rgba(var(--hk-accent-rgb), 0.22);
-  --theme-preview: linear-gradient(
-    135deg,
-    rgba(var(--hk-accent-rgb), 0.5),
-    rgba(var(--hk-accent-rgb), 0.1)
-  );
-  --theme-font-family: var(--hk-heading-font-family);
-  display: grid;
-  gap: 0.75rem;
-  padding: 1.1rem 1.25rem;
-  border-radius: 1.15rem;
-  border: 1px solid var(--profile-border);
-  background: var(--profile-surface-subtle);
-  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
-  cursor: pointer;
-  position: relative;
-  min-height: 100%;
-}
-
-.theme-option__card:hover {
-  transform: translateY(-2px);
-  border-color: var(--profile-border-strong);
-}
-
-.theme-option__card--active {
-  border-color: var(--theme-accent);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18), 0 0 0 1px var(--theme-accent);
-}
-
-.theme-option__input:focus-visible + .theme-option__card {
-  box-shadow: 0 0 0 1px var(--theme-accent), 0 0 0 4px var(--theme-soft-accent);
-}
-
-.theme-option__card--active .theme-option__title {
-  color: var(--theme-accent);
-}
-
-.theme-option__preview {
-  height: 3rem;
-  border-radius: 0.85rem;
-  background-image: var(--theme-preview);
-  border: 1px solid var(--profile-border);
-}
-
-.theme-option__content {
-  display: grid;
-  gap: 0.35rem;
-}
-
-.theme-option__title {
-  font-weight: 600;
-  font-family: var(--theme-font-family, var(--hk-heading-font-family));
-  letter-spacing: var(--hk-heading-letter-spacing, 0.03em);
-}
-
-.theme-option__description {
-  color: var(--profile-text-muted);
-  font-size: 0.95rem;
-}
-
-.theme-option__badge {
-  justify-self: start;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  background: var(--theme-soft-accent);
-  color: var(--theme-accent);
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
 }
 
 .profile__xp-progress {
@@ -202,124 +88,263 @@
   background: var(--hk-accent-gradient-progress);
 }
 
-.profile__achievements,
-.profile__loot {
+.profile__sheet {
   display: grid;
-  gap: 1.25rem;
+  gap: 1.5rem;
 }
 
-.profile__achievements > header,
-.profile__loot > header {
+.profile__sheet > header {
   display: grid;
   gap: 0.35rem;
 }
 
-.profile__achievements > header h2,
-.profile__loot > header h2 {
+.profile__sheet > header h2 {
   margin: 0;
 }
 
-.profile__achievements > header p,
-.profile__loot > header p {
+.profile__sheet > header p {
   margin: 0;
   color: var(--profile-text-muted);
 }
 
-.profile__achievements ul,
-.profile__loot ul {
+.profile__sheet-body {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.profile__sheet-info {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--profile-border);
+  background: var(--profile-surface-subtle);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.profile__sheet-info > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.profile__sheet-info dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--profile-text-muted);
+  margin: 0;
+}
+
+.profile__sheet-info dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.profile__sheet-attributes,
+.profile__sheet-traits {
+  padding: 1.25rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--profile-border);
+  background: var(--profile-surface-subtle);
+  display: grid;
+  gap: 1rem;
+}
+
+.profile__sheet-attributes h3,
+.profile__sheet-traits h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+}
+
+.profile__sheet-attributes ul,
+.profile__sheet-traits ul {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-.achievement-card {
+.profile__sheet-attributes li {
   display: grid;
-  gap: 0.85rem;
-  padding: 1.25rem;
-  border-radius: 1.25rem;
-  background: var(--profile-surface-soft);
-  border: 1px solid var(--profile-border);
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
 }
 
-.achievement-card > header {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 1rem;
-  align-items: start;
-}
-
-.achievement-card__icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.9rem;
-  display: grid;
-  place-items: center;
-  background: radial-gradient(circle at top, #facc15, #f97316);
-  color: #16121f;
-  font-size: 1.2rem;
+.profile__attribute-label {
   font-weight: 600;
 }
 
-.achievement-card__title {
+.profile__attribute-meter {
+  position: relative;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.profile__attribute-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--hk-accent-gradient-progress);
+}
+
+.profile__attribute-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.profile__sheet-traits li {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.profile__sheet-traits li:last-child {
+  border-bottom: none;
+}
+
+.profile__sheet-traits strong {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.profile__sheet-traits p {
   margin: 0;
-  font-weight: 600;
-}
-
-.achievement-card__description {
-  margin: 0.25rem 0 0;
   color: var(--profile-text-muted);
   font-size: 0.95rem;
 }
 
-.achievement-card__progress {
-  position: relative;
-  height: 0.6rem;
-  border-radius: 999px;
-  background: var(--profile-progress-track);
+.profile__cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.profile-card {
+  border-radius: 1.25rem;
+  background: var(--profile-surface-subtle);
   overflow: hidden;
+  position: relative;
 }
 
-.achievement-card__progress-bar {
-  height: 100%;
+.profile-card__trigger {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  width: 100%;
+  padding: 1.25rem 1.5rem;
+  background: none;
+  border: 1px solid var(--profile-border);
   border-radius: inherit;
-  background: var(--hk-accent-gradient);
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
-.achievement-card__value {
-  justify-self: end;
-  font-size: 0.9rem;
+.profile-card__trigger:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 36px rgba(10, 12, 28, 0.28);
+  border-color: rgba(var(--hk-accent-rgb), 0.4);
+}
+
+.profile-card__icon {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.95rem;
+  display: grid;
+  place-items: center;
+  background: rgba(var(--hk-accent-rgb), 0.12);
+  color: var(--hk-accent);
+  font-size: 1.6rem;
+}
+
+.profile-card__content h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.profile-card__content p {
+  margin: 0.35rem 0 0;
   color: var(--profile-text-muted);
 }
 
-.profile__loot li {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
-  border-radius: 1.1rem;
-  border: 1px solid var(--profile-border);
-  background: var(--profile-surface-subtle);
-  font-size: 1rem;
+.profile-card__stats {
+  margin: 0.75rem 0 0;
+  display: grid;
+  gap: 0.5rem;
 }
 
-.profile__loot li[data-rarity='raro'] {
-  border-color: rgba(56, 189, 248, 0.5);
+.profile-card__stats > div {
+  display: grid;
+  gap: 0.2rem;
 }
 
-.profile__loot li[data-rarity='lendário'] {
-  border-color: rgba(250, 204, 21, 0.6);
-  box-shadow: 0 0 14px rgba(250, 204, 21, 0.24);
+.profile-card__stats dt {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--profile-text-muted);
 }
 
-.loot-card__name {
+.profile-card__stats dd {
+  margin: 0;
   font-weight: 600;
 }
 
-.loot-card__quantity {
-  color: var(--profile-text-muted);
+.profile-card__footer {
+  margin: 0.75rem 0 0;
+  color: var(--profile-text-secondary);
+  font-size: 0.9rem;
+}
+
+.profile-card__action {
+  align-self: center;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  background: rgba(var(--hk-accent-rgb), 0.12);
+  color: var(--hk-accent);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.profile-card__trigger:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.16), 0 0 0 6px rgba(var(--hk-accent-rgb), 0.2);
+  border-color: rgba(var(--hk-accent-rgb), 0.5);
+}
+
+:host ::ng-deep .profile-dialog-panel .mat-mdc-dialog-surface {
+  background: rgba(17, 21, 40, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
+  box-shadow: 0 30px 70px rgba(8, 10, 24, 0.5);
+  backdrop-filter: blur(18px);
+  color: var(--hk-text-primary);
+  padding: 0;
+}
+
+:host ::ng-deep .profile-dialog-panel--compact .mat-mdc-dialog-surface {
+  max-width: 720px;
+}
+
+:host ::ng-deep .profile-dialog-panel--wide .mat-mdc-dialog-surface {
+  max-width: 840px;
+}
+
+@media (max-width: 960px) {
+  .profile__sheet-body {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {
@@ -330,5 +355,14 @@
   .profile__header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .profile-card__trigger {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-card__icon,
+  .profile-card__action {
+    justify-self: flex-start;
   }
 }

--- a/src/app/features/profile/pages/profile.page.ts
+++ b/src/app/features/profile/pages/profile.page.ts
@@ -1,8 +1,41 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { DecimalPipe, NgFor, NgIf } from '@angular/common';
 import { HeroControlState } from '@app/core/state/hero-control.state';
-import { ThemeState, type ThemeId, type ThemeOption } from '@app/core/state/theme.state';
+import { ThemeState } from '@app/core/state/theme.state';
 import type { LootItem, ProfileAchievement } from '@app/core/state/hero-control.models';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { ProfileThemesDialogComponent } from '../components/profile-themes-dialog/profile-themes-dialog.component';
+import { ProfileAchievementsDialogComponent } from '../components/profile-achievements-dialog/profile-achievements-dialog.component';
+import { ProfileLootDialogComponent } from '../components/profile-loot-dialog/profile-loot-dialog.component';
+
+type HeroAttribute = {
+  readonly label: string;
+  readonly value: number;
+};
+
+type HeroTrait = {
+  readonly title: string;
+  readonly description: string;
+};
+
+type HeroSheet = {
+  readonly name: string;
+  readonly title: string;
+  readonly lineage: string;
+  readonly heroClass: string;
+  readonly guild: string;
+  readonly alignment: string;
+  readonly banner: string;
+  readonly signature: string;
+  readonly attributes: readonly HeroAttribute[];
+  readonly traits: readonly HeroTrait[];
+};
+
+const LOOT_RARITY_WEIGHT: Record<LootItem['rarity'], number> = {
+  comum: 1,
+  raro: 2,
+  lendário: 3,
+};
 
 @Component({
   selector: 'hk-profile-page',
@@ -10,11 +43,12 @@ import type { LootItem, ProfileAchievement } from '@app/core/state/hero-control.
   templateUrl: './profile.page.html',
   styleUrls: ['./profile.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgFor, DecimalPipe, NgIf],
+  imports: [NgFor, DecimalPipe, NgIf, MatDialogModule],
 })
 export class ProfilePageComponent {
   private readonly heroControl = inject(HeroControlState);
   private readonly themeState = inject(ThemeState);
+  private readonly dialog = inject(MatDialog);
 
   protected readonly experience = this.heroControl.experience;
   protected readonly experienceProgress = this.heroControl.experienceProgress;
@@ -23,23 +57,127 @@ export class ProfilePageComponent {
   protected readonly themes = this.themeState.themes;
   protected readonly currentTheme = this.themeState.currentTheme;
 
-  protected trackAchievement(_: number, achievement: ProfileAchievement): string {
-    return achievement.id;
+  protected readonly heroSheet: HeroSheet = {
+    name: 'Lia Stormforge',
+    title: 'Guardião do Fluxo Épico',
+    lineage: 'Humana da Cidade-porto de Valora',
+    heroClass: 'Estrategista Arcana (Suporte Tático)',
+    guild: 'Convergência Hero Kanban',
+    alignment: 'Ordem Inovadora (Leal & Criativo)',
+    banner: 'Estandarte Prisma da Iteração',
+    signature: 'Orbe da Daily Eterna',
+    attributes: [
+      { label: 'Estratégia', value: 18 },
+      { label: 'Colaboração', value: 17 },
+      { label: 'Resiliência', value: 16 },
+      { label: 'Execução', value: 15 },
+      { label: 'Criatividade', value: 15 },
+      { label: 'Carisma', value: 14 },
+    ],
+    traits: [
+      {
+        title: 'Aura Motivadora',
+        description: 'Concede +2 de moral a toda a party sempre que uma daily inicia no horário.',
+      },
+      {
+        title: 'Visão de Produto',
+        description: 'Permite revelar bloqueios ocultos um sprint antes de impactarem o roadmap.',
+      },
+      {
+        title: 'Runa de Refatoração',
+        description: 'Uma vez por ciclo, remove um bug crítico instantaneamente sem custo de mana.',
+      },
+    ],
+  };
+
+  protected readonly themesCount = computed(() => this.themes().length);
+
+  protected readonly currentThemeOption = computed(() =>
+    this.themes().find((theme) => theme.id === this.currentTheme()) ?? null,
+  );
+
+  protected readonly achievementsAverage = computed(() => {
+    const list = this.achievements();
+
+    if (!list.length) {
+      return 0;
+    }
+
+    const totalProgress = list.reduce((total, item) => total + item.progress, 0);
+    return Math.round(totalProgress / list.length);
+  });
+
+  protected readonly highlightedAchievement = computed(() => {
+    const list = this.achievements();
+
+    if (!list.length) {
+      return null;
+    }
+
+    return list.reduce<ProfileAchievement | null>((best, current) => {
+      if (best === null || current.progress > best.progress) {
+        return current;
+      }
+
+      return best;
+    }, null);
+  });
+
+  protected readonly completedAchievements = computed(() =>
+    this.achievements().filter((achievement) => achievement.progress >= 100).length,
+  );
+
+  protected readonly lootUniqueCount = computed(() => this.loot().length);
+
+  protected readonly lootTotalQuantity = computed(() =>
+    this.loot().reduce((total, item) => total + item.quantity, 0),
+  );
+
+  protected readonly featuredLoot = computed(() => {
+    const items = this.loot();
+
+    if (!items.length) {
+      return null;
+    }
+
+    return items.reduce<LootItem | null>((best, item) => {
+      if (best === null) {
+        return item;
+      }
+
+      const currentWeight = LOOT_RARITY_WEIGHT[item.rarity];
+      const bestWeight = LOOT_RARITY_WEIGHT[best.rarity];
+
+      if (currentWeight > bestWeight) {
+        return item;
+      }
+
+      if (currentWeight === bestWeight && item.quantity > best.quantity) {
+        return item;
+      }
+
+      return best;
+    }, null);
+  });
+
+  protected openThemesDialog(): void {
+    this.dialog.open(ProfileThemesDialogComponent, {
+      panelClass: ['profile-dialog-panel', 'profile-dialog-panel--compact'],
+      autoFocus: false,
+    });
   }
 
-  protected trackLoot(_: number, lootItem: LootItem): string {
-    return lootItem.id;
+  protected openAchievementsDialog(): void {
+    this.dialog.open(ProfileAchievementsDialogComponent, {
+      panelClass: 'profile-dialog-panel',
+      autoFocus: false,
+    });
   }
 
-  protected trackTheme(_: number, theme: ThemeOption): ThemeId {
-    return theme.id;
-  }
-
-  protected isThemeSelected(themeId: ThemeId): boolean {
-    return this.currentTheme() === themeId;
-  }
-
-  protected onThemeSelect(themeId: ThemeId): void {
-    this.themeState.setTheme(themeId);
+  protected openLootDialog(): void {
+    this.dialog.open(ProfileLootDialogComponent, {
+      panelClass: ['profile-dialog-panel', 'profile-dialog-panel--wide'],
+      autoFocus: false,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- rework the profile page to spotlight a full RPG-inspired hero sheet and compact summary cards
- add dedicated Angular Material dialogs to manage themes, achievements and loot inventories
- update the profile styling and dialog skins to align with the new modal-driven navigation

## Testing
- npm run build *(fails: existing Angular budget limit on story-details.page.scss)*

------
https://chatgpt.com/codex/tasks/task_e_68e3130966e0833395ec9c8cb64fc752