### PR TITLE
fix: ensure profile themes load from backend

### DIFF
--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { inject, Injectable, signal, effect } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { OverlayContainer } from '@angular/cdk/overlay';
 
 import {
@@ -39,29 +39,25 @@ export class ThemeState {
   readonly themes = this._themes.asReadonly();
   readonly currentTheme = this._currentTheme.asReadonly();
 
-  private readonly hydrateThemesEffect = effect(
-    () => {
-      const subscription = this.themeService
-        .getThemes()
-        .pipe(take(1))
-        .subscribe({
-          next: (themes) => {
-            if (themes.length > 0) {
-              this.setAvailableThemes(themes);
-            }
-          },
-          error: () => {
-            // Keep the current theme when the backend is unavailable.
-          },
-        });
-
-      return () => subscription.unsubscribe();
-    },
-    { allowSignalWrites: true },
-  );
-
   constructor() {
     this.applyTheme(this._currentTheme());
+    this.hydrateThemes();
+  }
+
+  private hydrateThemes(): void {
+    this.themeService
+      .getThemes()
+      .pipe(take(1))
+      .subscribe({
+        next: (themes) => {
+          if (themes.length > 0) {
+            this.setAvailableThemes(themes);
+          }
+        },
+        error: () => {
+          // Keep the current theme when the backend is unavailable.
+        },
+      });
   }
 
   setAvailableThemes(themes: readonly ThemeOption[]): void {


### PR DESCRIPTION
## Summary
- trigger ThemeState to hydrate theme options when the service is created so the profile dialog lists available themes
- refactor the ThemeState test stub to make backend responses configurable and cover the hydration behaviour

## Testing
- CI=1 npm run test -- --watch=false *(fails: Chrome browser binary is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b49b16b08333b9018f303d37ee9c