### PR TITLE
feat: provide fallback themes for the profile dialog

### DIFF
--- a/src/app/core/state/theme.defaults.ts
+++ b/src/app/core/state/theme.defaults.ts
@@ -1,0 +1,80 @@
+import type { ThemeOption } from './theme.config';
+
+const FALLBACK_THEME_DATA = [
+  {
+    id: 'stellar-night',
+    label: 'Noite Estelar',
+    description: 'Tema original com tons profundos e acento violeta.',
+    accent: '#7c5cff',
+    softAccent: 'rgba(124, 92, 255, 0.28)',
+    previewGradient: 'linear-gradient(135deg, #1b1933 0%, #433978 100%)',
+    tone: 'dark',
+    previewFontFamily: "'Chakra Petch', 'Inter', 'Segoe UI', sans-serif",
+    isDefault: true,
+    profile: {
+      textPrimary: 'var(--hk-text-primary)',
+      textSecondary: 'var(--hk-text-secondary)',
+      textMuted: 'var(--hk-text-muted)',
+      border: 'rgba(255, 255, 255, 0.08)',
+      borderStrong: 'rgba(255, 255, 255, 0.18)',
+      surface: 'rgba(13, 16, 34, 0.8)',
+      surfaceSoft: 'rgba(255, 255, 255, 0.06)',
+      surfaceSubtle: 'rgba(255, 255, 255, 0.03)',
+      progressTrack: 'rgba(124, 92, 255, 0.16)',
+      shadow: '0 28px 60px rgba(10, 12, 28, 0.45)',
+    },
+  },
+  {
+    id: 'aurora-crest',
+    label: 'Aurora Boreal',
+    description: 'Mistura esmeralda e azul para uma interface energizante.',
+    accent: '#1dd3b0',
+    softAccent: 'rgba(29, 211, 176, 0.25)',
+    previewGradient: 'linear-gradient(135deg, #012a4a 0%, #036666 100%)',
+    tone: 'dark',
+    previewFontFamily: "'Space Grotesk', 'Rubik', 'Segoe UI', sans-serif",
+    profile: {
+      textPrimary: 'var(--hk-text-primary)',
+      textSecondary: 'var(--hk-text-secondary)',
+      textMuted: 'var(--hk-text-muted)',
+      border: 'rgba(255, 255, 255, 0.08)',
+      borderStrong: 'rgba(255, 255, 255, 0.18)',
+      surface: 'rgba(13, 16, 34, 0.8)',
+      surfaceSoft: 'rgba(255, 255, 255, 0.06)',
+      surfaceSubtle: 'rgba(255, 255, 255, 0.03)',
+      progressTrack: 'rgba(124, 92, 255, 0.16)',
+      shadow: '0 28px 60px rgba(10, 12, 28, 0.45)',
+    },
+  },
+  {
+    id: 'radiant-dawn',
+    label: 'Aurora Matinal',
+    description: 'Tema claro com foco em clareza e contrastes azulados.',
+    accent: '#2563eb',
+    softAccent: 'rgba(37, 99, 235, 0.18)',
+    previewGradient: 'linear-gradient(135deg, #f1f5ff 0%, #cfe1ff 100%)',
+    tone: 'light',
+    previewFontFamily: "'Inter', 'Segoe UI', sans-serif",
+    profile: {
+      textPrimary: '#0f172a',
+      textSecondary: '#1f2937',
+      textMuted: '#64748b',
+      border: 'rgba(15, 23, 42, 0.08)',
+      borderStrong: 'rgba(15, 23, 42, 0.16)',
+      surface: '#ffffff',
+      surfaceSoft: 'rgba(226, 232, 240, 0.65)',
+      surfaceSubtle: 'rgba(226, 232, 240, 0.45)',
+      progressTrack: 'rgba(15, 23, 42, 0.1)',
+      shadow: '0 24px 48px rgba(15, 23, 42, 0.12)',
+    },
+  },
+] as const satisfies readonly ThemeOption[];
+
+export const FALLBACK_THEMES: readonly ThemeOption[] = Object.freeze(
+  FALLBACK_THEME_DATA.map((theme) =>
+    Object.freeze({
+      ...theme,
+      profile: theme.profile ? Object.freeze({ ...theme.profile }) : undefined,
+    }),
+  ),
+);

--- a/src/app/core/state/theme.state.ts
+++ b/src/app/core/state/theme.state.ts
@@ -8,6 +8,7 @@ import {
   type ThemeOption,
   type ThemeProfileTokens,
 } from './theme.config';
+import { FALLBACK_THEMES } from './theme.defaults';
 import { ThemeService } from '../services/theme.service';
 import { take } from 'rxjs/operators';
 
@@ -30,7 +31,7 @@ export class ThemeState {
   private readonly overlayContainer = inject(OverlayContainer, { optional: true });
   private readonly themeService = inject(ThemeService);
 
-  private readonly _themes = signal<readonly ThemeOption[]>([]);
+  private readonly _themes = signal<readonly ThemeOption[]>(FALLBACK_THEMES);
 
   private readonly _currentTheme = signal<ThemeId>(DEFAULT_THEME_ID);
 


### PR DESCRIPTION
## Summary
- add a curated fallback list of themes that is always available locally
- initialize the theme state with the fallback list so the dialog renders options before the API responds

## Testing
- CI=true npm run test -- --watch=false *(fails: Chrome browser binary not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b6f6f0c883338a422224d766ba2c