### PR TITLE
fix: align profile modal background with active theme

### DIFF
--- a/src/app/features/profile/components/profile-modal/profile-modal.component.scss
+++ b/src/app/features/profile/components/profile-modal/profile-modal.component.scss
@@ -12,6 +12,9 @@
   grid-template-rows: auto minmax(0, 1fr) auto;
   gap: 1.75rem;
   padding: clamp(1.5rem, 2vw, 2.5rem);
+  border-radius: clamp(1.25rem, 2vw, 1.75rem);
+  border: 1px solid color-mix(in srgb, var(--hk-border) 85%, transparent);
+  background: color-mix(in srgb, var(--hk-surface-elevated) 92%, transparent);
   color: var(--hk-text-primary);
   max-height: inherit;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- ensure the profile modal panel uses themed surface colors, borders and radius so the background reacts to the active theme

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5bc59879c83339a8432ba992eea0a